### PR TITLE
Fix rust-analyzer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ proptest = "1.0.0"
 
 [patch.crates-io]
 olm-rs = { path = "vendor/olm-rs" }
+ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek", rev = "ad461f4f0f56507a2945510dedb914b3d3547c40" }


### PR DESCRIPTION
This patch fixes rust-analyzer on vscode, by temporarily patching the requirements to a commit version of `ed25519-dalek`

You can see the differences here: https://github.com/dalek-cryptography/ed25519-dalek/compare/1.0.1...ad461f4f0f56507a2945510dedb914b3d3547c40

The following difference is what makes this patch workable;

```diff
-#![cfg(not(test))]
-#![forbid(unsafe_code)]
+#![cfg_attr(not(test), forbid(unsafe_code))]
```

From https://github.com/dalek-cryptography/ed25519-dalek/issues/173;

> Yes since this was added in 1.0.1, rust-analyzer is not happy since it compiles everything in test mode

This should be applied as long as `ed25519-dalek` 1.1 isn't out, or this crate has to be published to crates.io