### PR TITLE
Use a ReusableSecret for the Sas curve25519 secret key

### DIFF
--- a/src/sas.rs
+++ b/src/sas.rs
@@ -222,7 +222,7 @@ impl Sas {
     ///
     /// # Security
     ///
-    /// Please note that this method *must* only be called once, if the method
+    /// Please note that this method *must* be called only once. If the method
     /// fails or we receive another public key another [`Sas`] object needs to
     /// be created.
     pub fn diffie_hellman(
@@ -246,8 +246,9 @@ impl Sas {
     ///
     /// # Security
     ///
-    /// Please note that this method *must* only be called once, if the method
+    /// Please note that this method *must* be called only once. If the method
     /// fails or we receive another public key another [`Sas`] object needs to
+    /// be created.
     pub fn diffie_hellman_with_raw(
         &self,
         other_public_key: &str,


### PR DESCRIPTION
Methods that take self can't easily be bound over FFI, since the
intetion of this crate is to work in various languages let's switch to a
method that takes a borrow of self.

This is a bit unfortunate since we do not want people to reuse the
secret key here.
