### PR TITLE
Revert "fix(sas): Use a ReusableSecret for the Sas curve25519 secret key"

### DIFF
--- a/src/sas.rs
+++ b/src/sas.rs
@@ -56,7 +56,7 @@ use hmac::{digest::MacError, Hmac, Mac};
 use rand::thread_rng;
 use sha2::Sha256;
 use thiserror::Error;
-use x25519_dalek::{ReusableSecret, SharedSecret};
+use x25519_dalek::{EphemeralSecret, SharedSecret};
 
 use crate::{
     utilities::{base64_decode, base64_encode},
@@ -99,7 +99,7 @@ pub enum PublicKeyError {
 /// This object can be used to establish a shared secret to perform the short
 /// auth string based key verification.
 pub struct Sas {
-    secret_key: ReusableSecret,
+    secret_key: EphemeralSecret,
     public_key: Curve25519PublicKey,
     encoded_public_key: String,
 }
@@ -202,7 +202,7 @@ impl Sas {
     pub fn new() -> Self {
         let rng = thread_rng();
 
-        let secret_key = ReusableSecret::new(rng);
+        let secret_key = EphemeralSecret::new(rng);
         let public_key = Curve25519PublicKey::from(&secret_key);
         let encoded_public_key = base64_encode(public_key.as_bytes());
 
@@ -224,14 +224,8 @@ impl Sas {
     ///
     /// Returns an [`EstablishedSas`] object which can be used to generate
     /// [`SasBytes`] if the given public key was valid, otherwise `None`.
-    ///
-    /// # Security
-    ///
-    /// Please note that this method *must* be called only once. If the method
-    /// fails or we receive another public key another [`Sas`] object needs to
-    /// be created.
     pub fn diffie_hellman(
-        &self,
+        self,
         other_public_key: Curve25519PublicKey,
     ) -> Result<EstablishedSas, PublicKeyError> {
         let shared_secret = self.secret_key.diffie_hellman(&other_public_key.inner);
@@ -248,14 +242,8 @@ impl Sas {
     ///
     /// Returns an [`EstablishedSas`] object which can be used to generate
     /// [`SasBytes`] if the received public key is valid, otherwise `None`.
-    ///
-    /// # Security
-    ///
-    /// Please note that this method *must* be called only once. If the method
-    /// fails or we receive another public key another [`Sas`] object needs to
-    /// be created.
     pub fn diffie_hellman_with_raw(
-        &self,
+        self,
         other_public_key: &str,
     ) -> Result<EstablishedSas, PublicKeyError> {
         let other_public_key = Curve25519PublicKey::from_base64(other_public_key)?;


### PR DESCRIPTION
We switched to using a ReusableSecret due to FFI reasons, but some language binding libs support taking self and those that do not can easily wrap the vodozemac Sas object in an Option.

This reverts commit 6976cca186cbf04061cfa558771f8203fcb11acf.