### PR TITLE
fix(olm): Decrypt the message when we create an inbound Session

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ channel.
 
 ```rust
 use anyhow::Result;
-use vodozemac::olm::{Account, OlmMessage};
+use vodozemac::olm::{Account, OlmMessage, InboundCreationResult};
 
 fn main() -> Result<()> {
     let alice = Account::new();
@@ -76,12 +76,13 @@ fn main() -> Result<()> {
     let alice_msg = alice_session.encrypt(message);
 
     if let OlmMessage::PreKey(m) = alice_msg.clone() {
-        let mut bob_session = bob
-            .create_inbound_session(alice.curve25519_key(), &m)?;
+        let result = bob.create_inbound_session(alice.curve25519_key(), &m)?;
+
+        let mut bob_session = result.session;
+        let what_bob_received = result.plaintext;
 
         assert_eq!(alice_session.session_id(), bob_session.session_id());
 
-        let what_bob_received = bob_session.decrypt(&alice_msg)?;
         assert_eq!(message, what_bob_received);
 
         let bob_reply = "Yes. Take this, it's dangerous out there!";

--- a/src/olm/messages/mod.rs
+++ b/src/olm/messages/mod.rs
@@ -14,7 +14,9 @@
 
 mod inner;
 
-pub(crate) use inner::{OlmMessage as InnerMessage, PreKeyMessage as InnerPreKeyMessage};
+pub(crate) use inner::{
+    DecodedMessage, OlmMessage as InnerMessage, PreKeyMessage as InnerPreKeyMessage,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Message {

--- a/src/olm/mod.rs
+++ b/src/olm/mod.rs
@@ -21,6 +21,6 @@ mod session;
 mod session_keys;
 mod shared_secret;
 
-pub use account::{Account, AccountPickledJSON};
+pub use account::{Account, AccountPickledJSON, InboundCreationResult};
 pub use messages::OlmMessage;
 pub use session::{DecryptionError, Session, SessionPickledJSON};

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -148,6 +148,12 @@ pub struct Session {
     receiving_chains: ChainStore,
 }
 
+impl std::fmt::Debug for Session {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Session").field("session_id", &self.session_id()).finish_non_exhaustive()
+    }
+}
+
 impl Session {
     pub(super) fn new(shared_secret: Shared3DHSecret, session_keys: SessionKeys) -> Self {
         let local_ratchet = DoubleRatchet::active(shared_secret);

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -44,7 +44,9 @@ use super::{
     shared_secret::{RemoteShared3DHSecret, Shared3DHSecret},
 };
 use crate::{
-    olm::messages::{InnerMessage, InnerPreKeyMessage, Message, OlmMessage, PreKeyMessage},
+    olm::messages::{
+        DecodedMessage, InnerMessage, InnerPreKeyMessage, Message, OlmMessage, PreKeyMessage,
+    },
     utilities::{base64_decode, base64_encode},
     Curve25519PublicKey, DecodeError,
 };
@@ -254,6 +256,14 @@ impl Session {
         let message = InnerMessage::from(message);
         let decoded = message.decode()?;
 
+        self.decrypt_decoded(message, decoded)
+    }
+
+    pub(super) fn decrypt_decoded(
+        &mut self,
+        message: InnerMessage,
+        decoded: DecodedMessage,
+    ) -> Result<Vec<u8>, DecryptionError> {
         let ratchet_key = RemoteRatchetKey::from(decoded.ratchet_key);
 
         if let Some(ratchet) = self.receiving_chains.find_ratchet(&ratchet_key) {


### PR DESCRIPTION
The API to create an inbound Session in libolm has three distinct steps:

1. Create a Session from a pre-key message
2. Decrypt the pre-key message
3. Remove the one-time key that was used to create the Session in step 1

This API is a bit problematic since it places the burden on the user to remove used up one-time keys. Furthermore it requires the pre-key message to be decoded twice, once for the Session creation step and once
for the decryption step.

vodozemac removed problem one by removing the one-time key when the Session has been created. This creates another problem, it lets users remove private one-time keys from our pool without actually using them
up. The user can create a Session on our side without ever producing a valid encrypted message for the Session.

This in turn results in unsuspecting users trying to communicate with us with a one-time key that we already have removed.

Luckily we can just decrypt the message at the Session creation step and combine the three mentioned steps into a single API call. This removes all mentioned problems.