### PR TITLE
Refactor our types an clean up the pickling logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub mod megolm;
 pub mod olm;
 pub mod sas;
 
-pub use types::{Curve25519KeyError, Curve25519PublicKey};
+pub use types::{Curve25519KeyError, Curve25519PublicKey, Ed25519PublicKey, SignatureError};
 
 #[derive(Debug, thiserror::Error)]
 pub enum LibolmUnpickleError {
@@ -47,7 +47,7 @@ pub enum LibolmUnpickleError {
     #[error("The pickle couldn't be decrypted: {0}")]
     Decryption(#[from] crate::cipher::DecryptionError),
     #[error("The pickle contained an invalid ed25519 public key {0}")]
-    PublicKey(#[from] ed25519_dalek::SignatureError),
+    PublicKey(#[from] SignatureError),
     #[error("The pickle didn't contain a valid Olm session")]
     InvalidSession,
 }
@@ -65,7 +65,7 @@ pub enum DecodeError {
     #[error("The message contained a MAC with an invalid size, expected {0}, got {1}")]
     InvalidMacLength(usize, usize),
     #[error("The message contained an invalid Signature: {0}")]
-    Signature(#[from] ed25519_dalek::SignatureError),
+    Signature(#[from] SignatureError),
     #[error(transparent)]
     ProtoBufError(#[from] prost::DecodeError),
 }

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -21,7 +21,6 @@ use std::{
     ops::Deref,
 };
 
-use ed25519_dalek::{ExpandedSecretKey as Ed25519PrivateKey, PublicKey as Ed25519PublicKey};
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -41,7 +40,7 @@ use super::{
 use crate::{
     types::{
         Curve25519Keypair, Curve25519KeypairPickle, Curve25519PublicKey, Ed25519Keypair,
-        Ed25519KeypairPickle, Ed25519KeypairUnpicklingError, KeyId,
+        Ed25519KeypairPickle, Ed25519KeypairUnpicklingError, Ed25519PublicKey, KeyId,
     },
     utilities::{base64_decode, base64_encode},
     DecodeError,
@@ -354,7 +353,8 @@ impl Account {
             let mut private_key = [0u8; 64];
             cursor.read_exact(&mut private_key)?;
 
-            let private_ed25519_key = Ed25519PrivateKey::from_bytes(&private_key)?;
+            let signing_key = Ed25519Keypair::from_expanded_key(&private_key)?;
+            private_key.zeroize();
 
             let secret_key = read_curve_key(&mut cursor)?;
             let public_key = Curve25519PublicKey::from(&secret_key);
@@ -416,8 +416,6 @@ impl Account {
             } else {
                 None
             };
-
-            let signing_key = Ed25519Keypair::from_expanded_key(private_ed25519_key);
 
             Ok(Self {
                 signing_key,

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -127,7 +127,7 @@ impl Account {
 
     /// Sign the given message using our Ed25519 fingerprint key.
     pub fn sign(&self, message: &str) -> String {
-        self.signing_key.sign(message)
+        self.signing_key.sign(message.as_bytes()).to_base64()
     }
 
     /// Convert the account into a struct which implements [`serde::Serialize`]
@@ -781,7 +781,7 @@ mod test {
         let account_with_expanded_key = Account::from_libolm_pickle(&pickle, key)?;
 
         let signing_key_clone = account_with_expanded_key.signing_key.clone();
-        signing_key_clone.sign("You met with a terrible fate, haven’t you?");
+        signing_key_clone.sign("You met with a terrible fate, haven’t you?".as_bytes());
         account_with_expanded_key.sign("You met with a terrible fate, haven’t you?");
 
         Ok(())

--- a/src/types/curve25519.rs
+++ b/src/types/curve25519.rs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ed25519_dalek::{
-    ExpandedSecretKey as ExpandedEd25519SecretKey, Keypair, PublicKey as Ed25519PublicKey,
-    SecretKey as UnexpandedEd25519SecretKey, SignatureError,
-};
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -25,119 +21,6 @@ use x25519_dalek::{
 use zeroize::Zeroize;
 
 use crate::utilities::{base64_decode, base64_encode, DecodeError};
-
-enum Ed25519SecretKey {
-    Normal(UnexpandedEd25519SecretKey),
-    Expanded(ExpandedEd25519SecretKey),
-}
-
-impl Ed25519SecretKey {
-    fn public_key(&self) -> Ed25519PublicKey {
-        match &self {
-            Ed25519SecretKey::Normal(k) => Ed25519PublicKey::from(k),
-            Ed25519SecretKey::Expanded(k) => Ed25519PublicKey::from(k),
-        }
-    }
-
-    fn sign(&self, message: &str, public_key: &Ed25519PublicKey) -> String {
-        let signature = match &self {
-            Ed25519SecretKey::Normal(k) => {
-                let expanded = ExpandedEd25519SecretKey::from(k);
-                expanded.sign(message.as_ref(), public_key)
-            }
-            Ed25519SecretKey::Expanded(k) => k.sign(message.as_ref(), public_key),
-        };
-
-        base64_encode(signature.to_bytes())
-    }
-}
-
-#[derive(Deserialize, Serialize)]
-#[serde(try_from = "Ed25519KeypairPickle")]
-#[serde(into = "Ed25519KeypairPickle")]
-pub(super) struct Ed25519Keypair {
-    secret_key: Ed25519SecretKey,
-    public_key: Ed25519PublicKey,
-    encoded_public_key: String,
-}
-
-impl Clone for Ed25519Keypair {
-    fn clone(&self) -> Self {
-        let secret_key: Result<Ed25519SecretKey, _> = match &self.secret_key {
-            Ed25519SecretKey::Normal(k) => {
-                UnexpandedEd25519SecretKey::from_bytes(k.as_bytes()).map(|k| k.into())
-            }
-            Ed25519SecretKey::Expanded(k) => {
-                let mut bytes = k.to_bytes();
-                let key = ExpandedEd25519SecretKey::from_bytes(&bytes).map(|k| k.into());
-                bytes.zeroize();
-
-                key
-            }
-        };
-
-        Self {
-            secret_key: secret_key.expect("Couldn't create a secret key copy."),
-            public_key: self.public_key,
-            encoded_public_key: self.encoded_public_key.clone(),
-        }
-    }
-}
-
-impl From<Ed25519Keypair> for Ed25519KeypairPickle {
-    fn from(key: Ed25519Keypair) -> Self {
-        match key.secret_key {
-            Ed25519SecretKey::Normal(k) => Ed25519KeypairPickle::Normal(k.as_bytes().to_vec()),
-            Ed25519SecretKey::Expanded(k) => Ed25519KeypairPickle::Expanded(k.to_bytes().to_vec()),
-        }
-    }
-}
-
-impl From<UnexpandedEd25519SecretKey> for Ed25519SecretKey {
-    fn from(key: UnexpandedEd25519SecretKey) -> Self {
-        Self::Normal(key)
-    }
-}
-
-impl From<ExpandedEd25519SecretKey> for Ed25519SecretKey {
-    fn from(key: ExpandedEd25519SecretKey) -> Self {
-        Self::Expanded(key)
-    }
-}
-
-impl Ed25519Keypair {
-    pub fn new() -> Self {
-        let mut rng = thread_rng();
-        let keypair = Keypair::generate(&mut rng);
-        let encoded_public_key = base64_encode(keypair.public.as_bytes());
-
-        Self { secret_key: keypair.secret.into(), public_key: keypair.public, encoded_public_key }
-    }
-
-    #[allow(dead_code)]
-    pub fn from_expanded_key(secret_key: ExpandedEd25519SecretKey) -> Self {
-        let public_key = Ed25519PublicKey::from(&secret_key);
-        let encoded_public_key = base64_encode(public_key.as_bytes());
-
-        Self { secret_key: secret_key.into(), public_key, encoded_public_key }
-    }
-
-    pub fn public_key(&self) -> &Ed25519PublicKey {
-        &self.public_key
-    }
-
-    pub fn public_key_encoded(&self) -> &str {
-        &self.encoded_public_key
-    }
-
-    pub fn sign(&self, message: &str) -> String {
-        self.secret_key.sign(message, self.public_key())
-    }
-}
-
-#[derive(Error, Debug)]
-#[error("Invalid Ed25519 keypair pickle: {0}")]
-pub struct Ed25519KeypairUnpicklingError(#[from] SignatureError);
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(from = "Curve25519KeypairPickle")]
@@ -170,21 +53,6 @@ impl Curve25519Keypair {
 
     pub fn public_key_encoded(&self) -> &str {
         &self.encoded_public_key
-    }
-}
-
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct KeyId(pub(super) u64);
-
-impl From<KeyId> for String {
-    fn from(value: KeyId) -> String {
-        value.to_base64()
-    }
-}
-
-impl KeyId {
-    pub fn to_base64(self) -> String {
-        base64_encode(self.0.to_be_bytes())
     }
 }
 
@@ -306,28 +174,6 @@ impl From<Curve25519Keypair> for Curve25519KeypairPickle {
             secret: key.secret_key.to_bytes(),
             public: key.public_key.to_bytes(),
         }
-    }
-}
-
-#[derive(Serialize, Deserialize, Zeroize)]
-#[zeroize(drop)]
-pub(super) enum Ed25519KeypairPickle {
-    Normal(Vec<u8>),
-    Expanded(Vec<u8>),
-}
-
-impl TryFrom<Ed25519KeypairPickle> for Ed25519Keypair {
-    type Error = Ed25519KeypairUnpicklingError;
-
-    fn try_from(pickle: Ed25519KeypairPickle) -> Result<Self, Self::Error> {
-        let secret_key: Ed25519SecretKey = match &pickle {
-            Ed25519KeypairPickle::Normal(k) => UnexpandedEd25519SecretKey::from_bytes(k)?.into(),
-            Ed25519KeypairPickle::Expanded(k) => ExpandedEd25519SecretKey::from_bytes(k)?.into(),
-        };
-
-        let public_key = secret_key.public_key();
-
-        Ok(Self { secret_key, public_key, encoded_public_key: base64_encode(public_key) })
     }
 }
 

--- a/src/types/ed25519.rs
+++ b/src/types/ed25519.rs
@@ -1,0 +1,159 @@
+// Copyright 2021 Denis Kasak, Damir Jelić
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ed25519_dalek::{
+    ExpandedSecretKey as ExpandedEd25519SecretKey, Keypair, PublicKey as Ed25519PublicKey,
+    SecretKey as UnexpandedEd25519SecretKey, SignatureError,
+};
+use rand::thread_rng;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use zeroize::Zeroize;
+
+use crate::utilities::base64_encode;
+
+enum Ed25519SecretKey {
+    Normal(UnexpandedEd25519SecretKey),
+    Expanded(ExpandedEd25519SecretKey),
+}
+
+impl Ed25519SecretKey {
+    fn public_key(&self) -> Ed25519PublicKey {
+        match &self {
+            Ed25519SecretKey::Normal(k) => Ed25519PublicKey::from(k),
+            Ed25519SecretKey::Expanded(k) => Ed25519PublicKey::from(k),
+        }
+    }
+
+    fn sign(&self, message: &str, public_key: &Ed25519PublicKey) -> String {
+        let signature = match &self {
+            Ed25519SecretKey::Normal(k) => {
+                let expanded = ExpandedEd25519SecretKey::from(k);
+                expanded.sign(message.as_ref(), public_key)
+            }
+            Ed25519SecretKey::Expanded(k) => k.sign(message.as_ref(), public_key),
+        };
+
+        base64_encode(signature.to_bytes())
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(try_from = "Ed25519KeypairPickle")]
+#[serde(into = "Ed25519KeypairPickle")]
+pub struct Ed25519Keypair {
+    secret_key: Ed25519SecretKey,
+    public_key: Ed25519PublicKey,
+    encoded_public_key: String,
+}
+
+impl Clone for Ed25519Keypair {
+    fn clone(&self) -> Self {
+        let secret_key: Result<Ed25519SecretKey, _> = match &self.secret_key {
+            Ed25519SecretKey::Normal(k) => {
+                UnexpandedEd25519SecretKey::from_bytes(k.as_bytes()).map(|k| k.into())
+            }
+            Ed25519SecretKey::Expanded(k) => {
+                let mut bytes = k.to_bytes();
+                let key = ExpandedEd25519SecretKey::from_bytes(&bytes).map(|k| k.into());
+                bytes.zeroize();
+
+                key
+            }
+        };
+
+        Self {
+            secret_key: secret_key.expect("Couldn't create a secret key copy."),
+            public_key: self.public_key,
+            encoded_public_key: self.encoded_public_key.clone(),
+        }
+    }
+}
+
+impl From<Ed25519Keypair> for Ed25519KeypairPickle {
+    fn from(key: Ed25519Keypair) -> Self {
+        match key.secret_key {
+            Ed25519SecretKey::Normal(k) => Ed25519KeypairPickle::Normal(k.as_bytes().to_vec()),
+            Ed25519SecretKey::Expanded(k) => Ed25519KeypairPickle::Expanded(k.to_bytes().to_vec()),
+        }
+    }
+}
+
+impl From<UnexpandedEd25519SecretKey> for Ed25519SecretKey {
+    fn from(key: UnexpandedEd25519SecretKey) -> Self {
+        Self::Normal(key)
+    }
+}
+
+impl From<ExpandedEd25519SecretKey> for Ed25519SecretKey {
+    fn from(key: ExpandedEd25519SecretKey) -> Self {
+        Self::Expanded(key)
+    }
+}
+
+impl Ed25519Keypair {
+    pub fn new() -> Self {
+        let mut rng = thread_rng();
+        let keypair = Keypair::generate(&mut rng);
+        let encoded_public_key = base64_encode(keypair.public.as_bytes());
+
+        Self { secret_key: keypair.secret.into(), public_key: keypair.public, encoded_public_key }
+    }
+
+    #[allow(dead_code)]
+    pub fn from_expanded_key(secret_key: ExpandedEd25519SecretKey) -> Self {
+        let public_key = Ed25519PublicKey::from(&secret_key);
+        let encoded_public_key = base64_encode(public_key.as_bytes());
+
+        Self { secret_key: secret_key.into(), public_key, encoded_public_key }
+    }
+
+    pub fn public_key(&self) -> &Ed25519PublicKey {
+        &self.public_key
+    }
+
+    pub fn public_key_encoded(&self) -> &str {
+        &self.encoded_public_key
+    }
+
+    pub fn sign(&self, message: &str) -> String {
+        self.secret_key.sign(message, self.public_key())
+    }
+}
+
+#[derive(Error, Debug)]
+#[error("Invalid Ed25519 keypair pickle: {0}")]
+pub struct Ed25519KeypairUnpicklingError(#[from] SignatureError);
+
+#[derive(Serialize, Deserialize, Zeroize)]
+#[zeroize(drop)]
+pub enum Ed25519KeypairPickle {
+    Normal(Vec<u8>),
+    Expanded(Vec<u8>),
+}
+
+impl TryFrom<Ed25519KeypairPickle> for Ed25519Keypair {
+    type Error = Ed25519KeypairUnpicklingError;
+
+    fn try_from(pickle: Ed25519KeypairPickle) -> Result<Self, Self::Error> {
+        let secret_key: Ed25519SecretKey = match &pickle {
+            Ed25519KeypairPickle::Normal(k) => UnexpandedEd25519SecretKey::from_bytes(k)?.into(),
+            Ed25519KeypairPickle::Expanded(k) => ExpandedEd25519SecretKey::from_bytes(k)?.into(),
+        };
+
+        let public_key = secret_key.public_key();
+
+        Ok(Self { secret_key, public_key, encoded_public_key: base64_encode(public_key) })
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use curve25519::{Curve25519Keypair, Curve25519KeypairPickle};
 pub(crate) use ed25519::{
     Ed25519Keypair, Ed25519KeypairPickle, Ed25519KeypairUnpicklingError, Ed25519Signature,
 };
-pub use ed25519::{Ed25519PublicKey, Signature, SIGNATURE_LENGTH};
+pub use ed25519::{Ed25519PublicKey, SignatureError};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,8 +17,10 @@ mod ed25519;
 
 pub use curve25519::{Curve25519KeyError, Curve25519PublicKey};
 pub(crate) use curve25519::{Curve25519Keypair, Curve25519KeypairPickle};
-pub use ed25519::Ed25519PublicKey;
-pub(crate) use ed25519::{Ed25519Keypair, Ed25519KeypairPickle, Ed25519KeypairUnpicklingError};
+pub(crate) use ed25519::{
+    Ed25519Keypair, Ed25519KeypairPickle, Ed25519KeypairUnpicklingError, Ed25519Signature,
+};
+pub use ed25519::{Ed25519PublicKey, Signature, SIGNATURE_LENGTH};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,36 @@
+// Copyright 2021 Denis Kasak, Damir Jelić
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod curve25519;
+mod ed25519;
+
+pub use curve25519::{Curve25519KeyError, Curve25519PublicKey};
+pub(crate) use curve25519::{Curve25519Keypair, Curve25519KeypairPickle};
+pub(crate) use ed25519::{Ed25519Keypair, Ed25519KeypairPickle, Ed25519KeypairUnpicklingError};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct KeyId(pub(super) u64);
+
+impl From<KeyId> for String {
+    fn from(value: KeyId) -> String {
+        value.to_base64()
+    }
+}
+
+impl KeyId {
+    pub fn to_base64(self) -> String {
+        crate::utilities::base64_encode(self.0.to_be_bytes())
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,6 +17,7 @@ mod ed25519;
 
 pub use curve25519::{Curve25519KeyError, Curve25519PublicKey};
 pub(crate) use curve25519::{Curve25519Keypair, Curve25519KeypairPickle};
+pub use ed25519::Ed25519PublicKey;
 pub(crate) use ed25519::{Ed25519Keypair, Ed25519KeypairPickle, Ed25519KeypairUnpicklingError};
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
This PR makes sure that we don't use ed25519-dalek types directly, instead we use our wrapper types and re-exports.

This comes in handy because we need to convert to/from base64 and we may switch ed25519 libs. It also makes it easy to put the verify/verify_strict method of the ed25519 public keys behind a feature flag.