### PR TITLE
Simplify our serialization logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,10 @@ only *unpickling* is supported.
 
 ### Modern pickles
 
-The modern pickling mechanism used by this crate. The serialization format is
-based on Serde.
+The crate also implements a modern pickling mechanism using
+[Serde](https://serde.rs/). The exact serialization format is not mandated or
+specified by this crate, but you can serialize to and deserialize from any
+format supported by Serde.
 
 The following structs support pickling:
 
@@ -160,12 +162,15 @@ You can unpickle a pickle-able struct directly from its serialized form:
 ```rust
 # use anyhow::Result;
 # use vodozemac::olm::{Account, AccountPickle};
+# use zeroize::Zeroize;
 #
 # fn main() -> Result<()> {
 #   let some_account = Account::new();
-    let json_str = serde_json::to_string(&some_account.pickle())?;
-    // This will produce an account which is identitcal to `some_account`.
+    let mut json_str = serde_json::to_string(&some_account.pickle())?;
+    // This will produce an account which is identical to `some_account`.
     let account: Account = serde_json::from_str::<AccountPickle>(&json_str)?.into();
+
+    json_str.zeroize();
 #
 #    Ok(())
 # }

--- a/src/cipher/mod.rs
+++ b/src/cipher/mod.rs
@@ -107,7 +107,6 @@ impl Cipher {
         cipher.decrypt_vec(ciphertext)
     }
 
-    #[cfg(feature = "libolm-compat")]
     pub fn decrypt_pickle(&self, ciphertext: &[u8]) -> Result<Vec<u8>, DecryptionError> {
         if ciphertext.len() < Mac::TRUNCATED_LEN + 1 {
             Err(DecryptionError::MacMissing)
@@ -117,6 +116,15 @@ impl Cipher {
 
             Ok(self.decrypt(ciphertext)?)
         }
+    }
+
+    pub fn encrypt_pickle(&self, plaintext: &[u8]) -> Vec<u8> {
+        let mut ciphertext = self.encrypt(plaintext);
+        let mac = self.mac(&ciphertext);
+
+        ciphertext.extend(mac.truncate());
+
+        ciphertext
     }
 
     pub fn verify_mac(&self, message: &[u8], tag: &[u8]) -> Result<(), MacError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,16 @@ pub use types::{
     SignatureError,
 };
 
+#[derive(Debug, thiserror::Error)]
+pub enum UnpickleError {
+    #[error("The pickle wasn't valid base64: {0}")]
+    Base64(#[from] base64::DecodeError),
+    #[error("The pickle couldn't be decrypted: {0}")]
+    Decryption(#[from] crate::cipher::DecryptionError),
+    #[error("The pickle coudn't be deserialized: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
 #[cfg(feature = "libolm-compat")]
 #[derive(Debug, thiserror::Error)]
 pub enum LibolmUnpickleError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub enum PickleError {
     Base64(#[from] base64::DecodeError),
     #[error("The pickle couldn't be decrypted: {0}")]
     Decryption(#[from] crate::cipher::DecryptionError),
-    #[error("The pickle coudn't be deserialized: {0}")]
+    #[error("The pickle couldn't be deserialized: {0}")]
     Serialization(#[from] serde_json::Error),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub use types::{
 };
 
 #[derive(Debug, thiserror::Error)]
-pub enum UnpickleError {
+pub enum PickleError {
     #[error("The pickle wasn't valid base64: {0}")]
     Base64(#[from] base64::DecodeError),
     #[error("The pickle couldn't be decrypted: {0}")]
@@ -52,7 +52,7 @@ pub enum UnpickleError {
 
 #[cfg(feature = "libolm-compat")]
 #[derive(Debug, thiserror::Error)]
-pub enum LibolmUnpickleError {
+pub enum LibolmPickleError {
     #[error("The pickle doesn't contain a version")]
     MissingVersion,
     #[error("The pickle uses an unsupported version, expected {0}, got {1}")]

--- a/src/megolm/group_session.rs
+++ b/src/megolm/group_session.rs
@@ -20,7 +20,7 @@ use crate::{
     cipher::Cipher,
     types::Ed25519Keypair,
     utilities::{base64_encode, pickle, unpickle},
-    UnpickleError,
+    PickleError,
 };
 
 /// A Megolm group session represents a single sending participant in an
@@ -148,7 +148,7 @@ impl GroupSessionPickle {
         pickle(&self, pickle_key)
     }
 
-    pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, UnpickleError> {
+    pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, PickleError> {
         unpickle(ciphertext, pickle_key)
     }
 }

--- a/src/megolm/group_session.rs
+++ b/src/megolm/group_session.rs
@@ -130,7 +130,7 @@ impl GroupSession {
         GroupSessionPickle { ratchet: self.ratchet.clone(), signing_key: self.signing_key.clone() }
     }
 
-    /// Restore an [`GroupSession`] from a previously saved
+    /// Restore a [`GroupSession`] from a previously saved
     /// [`GroupSessionPickle`].
     pub fn from_pickle(pickle: GroupSessionPickle) -> Self {
         pickle.into()
@@ -148,16 +148,15 @@ pub struct GroupSessionPickle {
 impl GroupSessionPickle {
     /// Serialize and encrypt the pickle using the given key.
     ///
-    /// This method is the inverse of the
-    /// [`GroupSessionPickle::from_encrypted()`] method.
+    /// This is the inverse of [`GroupSessionPickle::from_encrypted`].
     pub fn encrypt(self, pickle_key: &[u8; 32]) -> String {
         pickle(&self, pickle_key)
     }
 
-    /// Decrypt and deserialize a pickle using the given ciphertext and key.
+    /// Obtain a pickle from a ciphertext by decrypting and deserializing using
+    /// the given key.
     ///
-    /// This method is the inverse of the [`GroupSessionPickle::encrypt()`]
-    /// method.
+    /// This is the inverse of [`GroupSessionPickle::encrypt`].
     pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, PickleError> {
         unpickle(ciphertext, pickle_key)
     }

--- a/src/megolm/group_session.rs
+++ b/src/megolm/group_session.rs
@@ -130,6 +130,8 @@ impl GroupSession {
         GroupSessionPickle { ratchet: self.ratchet.clone(), signing_key: self.signing_key.clone() }
     }
 
+    /// Restore an [`GroupSession`] from a previously saved
+    /// [`GroupSessionPickle`].
     pub fn from_pickle(pickle: GroupSessionPickle) -> Self {
         pickle.into()
     }
@@ -144,10 +146,18 @@ pub struct GroupSessionPickle {
 }
 
 impl GroupSessionPickle {
+    /// Serialize and encrypt the pickle using the given key.
+    ///
+    /// This method is the inverse of the
+    /// [`GroupSessionPickle::from_encrypted()`] method.
     pub fn encrypt(self, pickle_key: &[u8; 32]) -> String {
         pickle(&self, pickle_key)
     }
 
+    /// Decrypt and deserialize a pickle using the given ciphertext and key.
+    ///
+    /// This method is the inverse of the [`GroupSessionPickle::encrypt()`]
+    /// method.
     pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, PickleError> {
         unpickle(ciphertext, pickle_key)
     }

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -81,17 +81,12 @@ pub struct DecryptedMessage {
 
 #[derive(Zeroize, Serialize, Deserialize)]
 #[serde(transparent)]
+#[zeroize(drop)]
 pub struct ExportedSessionKey(pub String);
 
 impl ExportedSessionKey {
     pub fn as_str(&self) -> &str {
         &self.0
-    }
-}
-
-impl Drop for ExportedSessionKey {
-    fn drop(&mut self) {
-        self.0.zeroize()
     }
 }
 

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -340,16 +340,15 @@ pub struct InboundGroupSessionPickle {
 impl InboundGroupSessionPickle {
     /// Serialize and encrypt the pickle using the given key.
     ///
-    /// This method is the inverse of the
-    /// [`InboundGroupSessionPickle::from_encrypted()`] method.
+    /// This is the inverse of [`InboundGroupSessionPickle::from_encrypted`].
     pub fn encrypt(self, pickle_key: &[u8; 32]) -> String {
         pickle(&self, pickle_key)
     }
 
-    /// Decrypt and deserialize a pickle using the given ciphertext and key.
+    /// Obtain a pickle from a ciphertext by decrypting and deserializing using
+    /// the given key.
     ///
-    /// This method is the inverse of the
-    /// [`InboundGroupSessionPickle::encrypt()`] method.
+    /// This is the inverse of [`InboundGroupSessionPickle::encrypt`].
     pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, PickleError> {
         unpickle(ciphertext, pickle_key)
     }

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -241,6 +241,8 @@ impl InboundGroupSession {
         }
     }
 
+    /// Convert the inbound group session into a struct which implements
+    /// [`serde::Serialize`] and [`serde::Deserialize`].
     pub fn pickle(&self) -> InboundGroupSessionPickle {
         InboundGroupSessionPickle {
             initial_ratchet: self.initial_ratchet.clone(),
@@ -249,6 +251,8 @@ impl InboundGroupSession {
         }
     }
 
+    /// Restore an [`InboundGroupSession`] from a previously saved
+    /// [`InboundGroupSessionPickle`].
     pub fn from_pickle(pickle: InboundGroupSessionPickle) -> Self {
         Self::from(pickle)
     }
@@ -327,6 +331,9 @@ impl InboundGroupSession {
     }
 }
 
+/// A format suitable for serialization which implements [`serde::Serialize`]
+/// and [`serde::Deserialize`]. Obtainable by calling
+/// [`InboundGroupSession::pickle`].
 #[derive(Serialize, Deserialize)]
 pub struct InboundGroupSessionPickle {
     initial_ratchet: Ratchet,
@@ -336,10 +343,18 @@ pub struct InboundGroupSessionPickle {
 }
 
 impl InboundGroupSessionPickle {
+    /// Serialize and encrypt the pickle using the given key.
+    ///
+    /// This method is the inverse of the
+    /// [`InboundGroupSessionPickle::from_encrypted()`] method.
     pub fn encrypt(self, pickle_key: &[u8; 32]) -> String {
         pickle(&self, pickle_key)
     }
 
+    /// Decrypt and deserialize a pickle using the given ciphertext and key.
+    ///
+    /// This method is the inverse of the
+    /// [`InboundGroupSessionPickle::encrypt()`] method.
     pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, PickleError> {
         unpickle(ciphertext, pickle_key)
     }

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -27,7 +27,7 @@ use crate::{
     cipher::Cipher,
     types::{Ed25519PublicKey, Ed25519Signature, SignatureError},
     utilities::{base64_decode, base64_encode, pickle, unpickle, DecodeSecret},
-    DecodeError, UnpickleError,
+    DecodeError, PickleError,
 };
 
 const SESSION_KEY_EXPORT_VERSION: u8 = 1;
@@ -257,7 +257,7 @@ impl InboundGroupSession {
     pub fn from_libolm_pickle(
         pickle: &str,
         pickle_key: &str,
-    ) -> Result<Self, crate::LibolmUnpickleError> {
+    ) -> Result<Self, crate::LibolmPickleError> {
         use crate::utilities::{unpickle_libolm, Decode};
 
         #[derive(Zeroize)]
@@ -305,7 +305,7 @@ impl InboundGroupSession {
         }
 
         impl TryFrom<Pickle> for InboundGroupSession {
-            type Error = crate::LibolmUnpickleError;
+            type Error = crate::LibolmPickleError;
 
             fn try_from(pickle: Pickle) -> Result<Self, Self::Error> {
                 // Removing the borrow doesn't work and clippy complains about
@@ -340,7 +340,7 @@ impl InboundGroupSessionPickle {
         pickle(&self, pickle_key)
     }
 
-    pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, UnpickleError> {
+    pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, PickleError> {
         unpickle(ciphertext, pickle_key)
     }
 }

--- a/src/megolm/mod.rs
+++ b/src/megolm/mod.rs
@@ -28,17 +28,12 @@ pub use message::MegolmMessage;
 use zeroize::Zeroize;
 
 #[derive(Zeroize)]
+#[zeroize(drop)]
 pub struct SessionKey(pub String);
 
 impl SessionKey {
     pub fn as_str(&self) -> &str {
         &self.0
-    }
-}
-
-impl Drop for SessionKey {
-    fn drop(&mut self) {
-        self.0.zeroize()
     }
 }
 

--- a/src/megolm/ratchet.rs
+++ b/src/megolm/ratchet.rs
@@ -24,18 +24,14 @@ const ADVANCEMENT_SEEDS: [&[u8; 1]; Ratchet::RATCHET_PART_COUNT] =
     [b"\x00", b"\x01", b"\x02", b"\x03"];
 
 #[derive(Serialize, Deserialize, Zeroize, Clone)]
+#[zeroize(drop)]
 pub(super) struct Ratchet {
     inner: RatchetBytes,
     counter: u32,
 }
 
-impl Drop for Ratchet {
-    fn drop(&mut self) {
-        self.counter.zeroize();
-    }
-}
-
 #[derive(Zeroize, Clone)]
+#[zeroize(drop)]
 struct RatchetBytes(Box<[u8; Ratchet::RATCHET_LENGTH]>);
 
 impl RatchetBytes {
@@ -50,12 +46,6 @@ impl RatchetBytes {
 
             Ok(ratchet)
         }
-    }
-}
-
-impl Drop for RatchetBytes {
-    fn drop(&mut self) {
-        self.0.zeroize();
     }
 }
 

--- a/src/megolm/ratchet.rs
+++ b/src/megolm/ratchet.rs
@@ -39,11 +39,11 @@ impl Drop for Ratchet {
 struct RatchetBytes(Box<[u8; Ratchet::RATCHET_LENGTH]>);
 
 impl RatchetBytes {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, RatchetError> {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, RatchetBytesError> {
         let length = bytes.len();
 
         if length != Ratchet::RATCHET_LENGTH {
-            Err(RatchetError::InvalidLength(length))
+            Err(RatchetBytesError::InvalidLength(length))
         } else {
             let mut ratchet = Self(Box::new([0u8; Ratchet::RATCHET_LENGTH]));
             ratchet.0.copy_from_slice(bytes);
@@ -246,7 +246,7 @@ impl Ratchet {
 }
 
 #[derive(Error, Debug)]
-enum RatchetError {
+enum RatchetBytesError {
     #[error("Invalid Megolm ratchet length: expected 128, got {0}")]
     InvalidLength(usize),
 }

--- a/src/megolm/ratchet.rs
+++ b/src/megolm/ratchet.rs
@@ -246,7 +246,7 @@ impl Ratchet {
 }
 
 #[derive(Error, Debug)]
-pub enum RatchetError {
+enum RatchetError {
     #[error("Invalid Megolm ratchet length: expected 128, got {0}")]
     InvalidLength(usize),
 }

--- a/src/olm/account/fallback_keys.rs
+++ b/src/olm/account/fallback_keys.rs
@@ -137,5 +137,3 @@ mod test {
         assert_eq!(secret_bytes, fetched_key.to_bytes());
     }
 }
-
-pub(super) type FallbackKeysPickle = FallbackKeys;

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -39,7 +39,7 @@ use crate::{
         Ed25519KeypairPickle, Ed25519PublicKey, KeyId,
     },
     utilities::{base64_encode, pickle, unpickle, DecodeSecret},
-    DecodeError, UnpickleError,
+    DecodeError, PickleError,
 };
 
 const PUBLIC_MAX_ONE_TIME_KEYS: usize = 50;
@@ -347,7 +347,7 @@ impl Account {
     pub fn from_libolm_pickle(
         pickle: &str,
         pickle_key: &str,
-    ) -> Result<Self, crate::LibolmUnpickleError> {
+    ) -> Result<Self, crate::LibolmPickleError> {
         use self::fallback_keys::FallbackKey;
         use crate::utilities::{unpickle_libolm, Decode};
 
@@ -451,7 +451,7 @@ impl Account {
         }
 
         impl TryFrom<Pickle> for Account {
-            type Error = crate::LibolmUnpickleError;
+            type Error = crate::LibolmPickleError;
 
             fn try_from(pickle: Pickle) -> Result<Self, Self::Error> {
                 let mut one_time_keys = OneTimeKeys::new();
@@ -526,7 +526,7 @@ impl AccountPickle {
         pickle(&self, pickle_key)
     }
 
-    pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, UnpickleError> {
+    pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, PickleError> {
         unpickle(ciphertext, pickle_key)
     }
 }

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -334,6 +334,7 @@ impl Account {
         }
     }
 
+    /// Restore an [`Account`] from a previously saved [`AccountPickle`].
     pub fn from_pickle(pickle: AccountPickle) -> Self {
         pickle.into()
     }
@@ -522,10 +523,17 @@ pub struct AccountPickle {
 /// A format suitable for serialization which implements [`serde::Serialize`]
 /// and [`serde::Deserialize`]. Obtainable by calling [`Account::pickle`].
 impl AccountPickle {
+    /// Serialize and encrypt the pickle using the given key.
+    ///
+    /// This method is the inverse of the [`AccountPickle::from_encrypted()`]
+    /// method.
     pub fn encrypt(self, pickle_key: &[u8; 32]) -> String {
         pickle(&self, pickle_key)
     }
 
+    /// Decrypt and deserialize a pickle using the given ciphertext and key.
+    ///
+    /// This method is the inverse of the [`AccountPickle::encrypt()`] method.
     pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, PickleError> {
         unpickle(ciphertext, pickle_key)
     }

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -525,15 +525,15 @@ pub struct AccountPickle {
 impl AccountPickle {
     /// Serialize and encrypt the pickle using the given key.
     ///
-    /// This method is the inverse of the [`AccountPickle::from_encrypted()`]
-    /// method.
+    /// This is the inverse of [`AccountPickle::from_encrypted`].
     pub fn encrypt(self, pickle_key: &[u8; 32]) -> String {
         pickle(&self, pickle_key)
     }
 
-    /// Decrypt and deserialize a pickle using the given ciphertext and key.
+    /// Obtain a pickle from a ciphertext by decrypting and deserializing using
+    /// the given key.
     ///
-    /// This method is the inverse of the [`AccountPickle::encrypt()`] method.
+    /// This is the inverse of [`AccountPickle::encrypt`].
     pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, PickleError> {
         unpickle(ciphertext, pickle_key)
     }

--- a/src/olm/mod.rs
+++ b/src/olm/mod.rs
@@ -21,9 +21,6 @@ mod session;
 mod session_keys;
 mod shared_secret;
 
-pub use account::{
-    Account, AccountPickle, AccountPickledJSON, AccountUnpicklingError, IdentityKeys,
-    InboundCreationResult,
-};
+pub use account::{Account, AccountPickle, IdentityKeys, InboundCreationResult};
 pub use messages::{Message, MessageType, OlmMessage, PreKeyMessage};
-pub use session::{DecryptionError, Session, SessionPickle, SessionPickledJSON};
+pub use session::{DecryptionError, Session, SessionPickle};

--- a/src/olm/session/chain_key.rs
+++ b/src/olm/session/chain_key.rs
@@ -49,27 +49,17 @@ fn advance(key: &[u8; 32]) -> CtOutput<Hmac<Sha256>> {
 }
 
 #[derive(Clone, Zeroize, Serialize, Deserialize)]
+#[zeroize(drop)]
 pub(super) struct ChainKey {
     key: Box<[u8; 32]>,
     index: u64,
 }
 
-impl Drop for ChainKey {
-    fn drop(&mut self) {
-        self.key.zeroize()
-    }
-}
-
 #[derive(Clone, Zeroize, Serialize, Deserialize)]
+#[zeroize(drop)]
 pub(super) struct RemoteChainKey {
     key: Box<[u8; 32]>,
     index: u64,
-}
-
-impl Drop for RemoteChainKey {
-    fn drop(&mut self) {
-        self.key.zeroize()
-    }
 }
 
 impl RemoteChainKey {

--- a/src/olm/session/double_ratchet.rs
+++ b/src/olm/session/double_ratchet.rs
@@ -158,5 +158,3 @@ impl ActiveDoubleRatchet {
         message_key.encrypt(plaintext)
     }
 }
-
-pub(super) type DoubleRatchetPickle = DoubleRatchet;

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -40,7 +40,7 @@ use super::{
 use crate::{
     olm::messages::{Message, OlmMessage, PreKeyMessage},
     utilities::{base64_encode, pickle, unpickle, DecodeSecret},
-    Curve25519PublicKey, DecodeError, UnpickleError,
+    Curve25519PublicKey, DecodeError, PickleError,
 };
 
 const MAX_RECEIVING_CHAINS: usize = 5;
@@ -274,7 +274,7 @@ impl Session {
     pub fn from_libolm_pickle(
         pickle: &str,
         pickle_key: &str,
-    ) -> Result<Self, crate::LibolmUnpickleError> {
+    ) -> Result<Self, crate::LibolmPickleError> {
         use chain_key::ChainKey;
         use message_key::RemoteMessageKey;
         use ratchet::{Ratchet, RatchetKey};
@@ -403,7 +403,7 @@ impl Session {
         }
 
         impl TryFrom<Pickle> for Session {
-            type Error = crate::LibolmUnpickleError;
+            type Error = crate::LibolmPickleError;
 
             fn try_from(pickle: Pickle) -> Result<Self, Self::Error> {
                 let mut receiving_chains = ChainStore::new();
@@ -453,7 +453,7 @@ impl Session {
                         receiving_chains,
                     })
                 } else {
-                    Err(crate::LibolmUnpickleError::InvalidSession)
+                    Err(crate::LibolmPickleError::InvalidSession)
                 }
             }
         }
@@ -477,7 +477,7 @@ impl SessionPickle {
         pickle(&self, pickle_key)
     }
 
-    pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, UnpickleError> {
+    pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, PickleError> {
         unpickle(ciphertext, pickle_key)
     }
 }

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -476,15 +476,15 @@ pub struct SessionPickle {
 impl SessionPickle {
     /// Serialize and encrypt the pickle using the given key.
     ///
-    /// This method is the inverse of the [`SessionPickle::from_encrypted()`]
-    /// method.
+    /// This is the inverse of [`SessionPickle::from_encrypted`].
     pub fn encrypt(self, pickle_key: &[u8; 32]) -> String {
         pickle(&self, pickle_key)
     }
 
-    /// Decrypt and deserialize a pickle using the given ciphertext and key.
+    /// Obtain a pickle from a ciphertext by decrypting and deserializing using
+    /// the given key.
     ///
-    /// This method is the inverse of the [`SessionPickle::encrypt()`] method.
+    /// This is the inverse of [`SessionPickle::encrypt`].
     pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, PickleError> {
         unpickle(ciphertext, pickle_key)
     }

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -261,6 +261,7 @@ impl Session {
         }
     }
 
+    /// Restore a [`Session`] from a previously saved [`SessionPickle`].
     pub fn from_pickle(pickle: SessionPickle) -> Self {
         pickle.into()
     }
@@ -473,10 +474,17 @@ pub struct SessionPickle {
 }
 
 impl SessionPickle {
+    /// Serialize and encrypt the pickle using the given key.
+    ///
+    /// This method is the inverse of the [`SessionPickle::from_encrypted()`]
+    /// method.
     pub fn encrypt(self, pickle_key: &[u8; 32]) -> String {
         pickle(&self, pickle_key)
     }
 
+    /// Decrypt and deserialize a pickle using the given ciphertext and key.
+    ///
+    /// This method is the inverse of the [`SessionPickle::encrypt()`] method.
     pub fn from_encrypted(ciphertext: &str, pickle_key: &[u8; 32]) -> Result<Self, PickleError> {
         unpickle(ciphertext, pickle_key)
     }

--- a/src/olm/session_keys.rs
+++ b/src/olm/session_keys.rs
@@ -37,5 +37,3 @@ impl crate::utilities::Decode for SessionKeys {
         })
     }
 }
-
-pub(crate) type SessionKeysPickle = SessionKeys;

--- a/src/types/ed25519.rs
+++ b/src/types/ed25519.rs
@@ -304,21 +304,15 @@ impl From<ExpandedSecretKey> for SecretKeys {
     }
 }
 
-#[derive(Error, Debug)]
-#[error("Invalid Ed25519 keypair pickle: {0}")]
-pub struct Ed25519KeypairUnpicklingError(#[from] SignatureError);
-
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Ed25519KeypairPickle(SecretKeys);
 
-impl TryFrom<Ed25519KeypairPickle> for Ed25519Keypair {
-    type Error = Ed25519KeypairUnpicklingError;
-
-    fn try_from(pickle: Ed25519KeypairPickle) -> Result<Self, Self::Error> {
+impl From<Ed25519KeypairPickle> for Ed25519Keypair {
+    fn from(pickle: Ed25519KeypairPickle) -> Self {
         let secret_key = pickle.0;
         let public_key = secret_key.public_key();
 
-        Ok(Self { secret_key, public_key, encoded_public_key: public_key.to_base64() })
+        Self { secret_key, public_key, encoded_public_key: public_key.to_base64() }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -19,7 +19,7 @@ pub use curve25519::Curve25519PublicKey;
 #[cfg(feature = "libolm-compat")]
 pub(crate) use curve25519::Curve25519SecretKey;
 pub(crate) use curve25519::{Curve25519Keypair, Curve25519KeypairPickle};
-pub(crate) use ed25519::{Ed25519Keypair, Ed25519KeypairPickle, Ed25519KeypairUnpicklingError};
+pub(crate) use ed25519::{Ed25519Keypair, Ed25519KeypairPickle};
 pub use ed25519::{Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature, SignatureError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/src/utilities/libolm_compat.rs
+++ b/src/utilities/libolm_compat.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use zeroize::Zeroize;
 
 use super::base64_decode;
-use crate::{cipher::Cipher, LibolmUnpickleError};
+use crate::{cipher::Cipher, LibolmPickleError};
 
 /// Error type describing failure modes for libolm pickle decoding.
 #[derive(Debug, Error)]
@@ -44,11 +44,11 @@ pub enum LibolmDecodeError {
 /// * pickle_key - The key that was used to encrypt the libolm pickle
 /// * pickle_version - The expected version of the pickle. Unpickling will fail
 ///   if the version in the pickle doesn't match this one.
-pub(crate) fn unpickle_libolm<P: Decode, T: TryFrom<P, Error = LibolmUnpickleError>>(
+pub(crate) fn unpickle_libolm<P: Decode, T: TryFrom<P, Error = LibolmPickleError>>(
     pickle: &str,
     pickle_key: &str,
     pickle_version: u32,
-) -> Result<T, LibolmUnpickleError> {
+) -> Result<T, LibolmPickleError> {
     /// Fetch the pickle version from the given pickle source.
     fn get_version(source: &[u8]) -> Option<u32> {
         // Pickle versions are always u32 encoded as a fixed sized integer in
@@ -68,7 +68,7 @@ pub(crate) fn unpickle_libolm<P: Decode, T: TryFrom<P, Error = LibolmUnpickleErr
     // A pickle starts with a version, which will decide how we need to decode.
     // We only support the latest version so bail out if it isn't the expected
     // pickle version.
-    let version = get_version(&decrypted).ok_or(LibolmUnpickleError::MissingVersion)?;
+    let version = get_version(&decrypted).ok_or(LibolmPickleError::MissingVersion)?;
 
     if version == pickle_version {
         let mut cursor = Cursor::new(&decrypted);
@@ -77,7 +77,7 @@ pub(crate) fn unpickle_libolm<P: Decode, T: TryFrom<P, Error = LibolmUnpickleErr
         decrypted.zeroize();
         pickle.try_into()
     } else {
-        Err(LibolmUnpickleError::Version(pickle_version, version))
+        Err(LibolmPickleError::Version(pickle_version, version))
     }
 }
 

--- a/src/utilities/libolm_compat.rs
+++ b/src/utilities/libolm_compat.rs
@@ -40,7 +40,7 @@ pub enum LibolmDecodeError {
 ///
 /// # Arguments
 ///
-/// * pickle - The base64 encoded and encrypted libolm pickle string
+/// * pickle - The base64-encoded and encrypted libolm pickle string
 /// * pickle_key - The key that was used to encrypt the libolm pickle
 /// * pickle_version - The expected version of the pickle. Unpickling will fail
 ///   if the version in the pickle doesn't match this one.

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -33,7 +33,7 @@ pub fn base64_encode(input: impl AsRef<[u8]>) -> String {
 pub(crate) fn unpickle<T: for<'b> serde::Deserialize<'b>>(
     ciphertext: &str,
     pickle_key: &[u8; 32],
-) -> Result<T, crate::UnpickleError> {
+) -> Result<T, crate::PickleError> {
     use zeroize::Zeroize;
 
     let cipher = crate::cipher::Cipher::new_pickle(pickle_key);


### PR DESCRIPTION
A lot of types in our serialization logic seem to be of questionable usage. We should revise our serialization logic and where possible remove helper structs and use serde directly, this include error types.