### PR TITLE
Make `MessageType` public

### DIFF
--- a/src/olm/mod.rs
+++ b/src/olm/mod.rs
@@ -22,5 +22,5 @@ mod session_keys;
 mod shared_secret;
 
 pub use account::{Account, AccountPickledJSON, InboundCreationResult};
-pub use messages::OlmMessage;
+pub use messages::{MessageType, OlmMessage};
 pub use session::{DecryptionError, Session, SessionPickledJSON};


### PR DESCRIPTION
It's returned by `OlMessage::message_type()`.