### PR TITLE
Fix OTK pickling

### DIFF
--- a/src/olm/account/one_time_keys.rs
+++ b/src/olm/account/one_time_keys.rs
@@ -122,8 +122,8 @@ impl From<OneTimeKeysPickle> for OneTimeKeys {
     fn from(pickle: OneTimeKeysPickle) -> Self {
         let mut reverse_public_keys = HashMap::new();
 
-        for (k, v) in pickle.public_keys.clone().into_iter() {
-            reverse_public_keys.insert(v, k);
+        for (k, v) in pickle.private_keys.iter() {
+            reverse_public_keys.insert(v.into(), *k);
         }
 
         Self {


### PR DESCRIPTION
We remove the OTKs from the `public_keys` map once they're published, but we need to keep the entries in `reverse_public_keys` for as long as they're still in `private_keys`.

Not sure if we want to rename `reverse_public_keys`?