### PR TITLE
Make `Account::remove_one_time_key` public.

### DIFF
--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -203,7 +203,11 @@ impl Account {
             .or_else(|| self.fallback_keys.get_secret_key(public_key))
     }
 
-    fn remove_one_time_key(
+    /// Remove a one time key that has previously been published.
+    ///
+    /// **Note:** You do not need to manually call this after a one time key has
+    /// been used, as that is handled by [`Account::create_inbound_session`].
+    pub fn remove_one_time_key(
         &mut self,
         public_key: &Curve25519PublicKey,
     ) -> Option<Curve25519SecretKey> {

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -203,10 +203,13 @@ impl Account {
             .or_else(|| self.fallback_keys.get_secret_key(public_key))
     }
 
-    /// Remove a one time key that has previously been published.
+    /// Remove a one-time key that has previously been published but not yet
+    /// used.
     ///
-    /// **Note:** You do not need to manually call this after a one time key has
-    /// been used, as that is handled by [`Account::create_inbound_session`].
+    /// **Note**: This function is only rarely useful and you'll know if you
+    /// need it. Notably, you do *not* need to call it manually when using up
+    /// a key via [`Account::create_inbound_session`] since the key is
+    /// automatically removed in that case.
     pub fn remove_one_time_key(
         &mut self,
         public_key: &Curve25519PublicKey,


### PR DESCRIPTION
This is useful in rare circumstances where the caller wishes to remove
a one time key that hasn't been used.