### PR TITLE
vodozemac: Switch to bincode to decode libolm pickles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ strict-signatures = []
 aes = "0.7.5"
 arrayvec = { version = "0.7.2", features = ["serde"] }
 base64 = "0.13.0"
+bincode = { git = "https://github.com/poljar/bincode", rev = "6320ae1f38a3010f14a7cc71a55665139c4ef9c9" }
 block-modes = "0.8.1"
 ed25519-dalek = { version = "1.0.1", default-features = false, features = [
     "rand",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,10 +38,10 @@ pub use types::{Curve25519KeyError, Curve25519PublicKey, Ed25519PublicKey, Signa
 
 #[derive(Debug, thiserror::Error)]
 pub enum LibolmUnpickleError {
+    #[error("The pickle doesn't contain a version")]
+    MissingVersion,
     #[error("The pickle uses an unsupported version, expected {0}, got {1}")]
     Version(u32, u32),
-    #[error("The pickle didn't contain enough data to be decoded")]
-    InvalidSize(#[from] std::io::Error),
     #[error("The pickle wasn't valid base64: {0}")]
     Base64(#[from] base64::DecodeError),
     #[error("The pickle couldn't be decrypted: {0}")]
@@ -50,6 +50,8 @@ pub enum LibolmUnpickleError {
     PublicKey(#[from] SignatureError),
     #[error("The pickle didn't contain a valid Olm session")]
     InvalidSession,
+    #[error(transparent)]
+    Bincode(#[from] bincode::error::DecodeError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -20,10 +20,7 @@ mod ratchet;
 mod receiver_chain;
 mod root_key;
 
-use std::{
-    io::{Cursor, Read, Seek, SeekFrom},
-    ops::Deref,
-};
+use std::ops::Deref;
 
 use arrayvec::ArrayVec;
 use block_modes::BlockModeError;
@@ -45,7 +42,7 @@ use super::{
 };
 use crate::{
     olm::messages::{DecodedMessage, EncodedPrekeyMessage, Message, OlmMessage, PreKeyMessage},
-    utilities::{base64_decode, base64_encode},
+    utilities::base64_encode,
     Curve25519PublicKey, DecodeError,
 };
 
@@ -290,6 +287,122 @@ impl Session {
         )
     }
 
+    fn decode_libolm_pickle(pickle: &[u8]) -> Result<Self, crate::LibolmUnpickleError> {
+        use bincode::{Decode, Encode};
+        use chain_key::ChainKey;
+        use message_key::RemoteMessageKey;
+        use ratchet::{Ratchet, RatchetKey};
+        use root_key::RootKey;
+
+        use crate::{types::Curve25519SecretKey, utilities::decode_bincode};
+
+        #[derive(Debug, Decode, Encode, Zeroize)]
+        #[zeroize(drop)]
+        struct SenderChain {
+            public_ratchet_key: [u8; 32],
+            secret_ratchet_key: [u8; 32],
+            chain_key: [u8; 32],
+            chain_key_index: u32,
+        }
+
+        #[derive(Debug, Decode, Zeroize)]
+        #[zeroize(drop)]
+        struct ReceivingChain {
+            ratchet_key: [u8; 32],
+            chain_key: [u8; 32],
+            chain_key_index: u32,
+        }
+
+        impl From<&ReceivingChain> for ReceiverChain {
+            fn from(chain: &ReceivingChain) -> Self {
+                let ratchet_key = RemoteRatchetKey::from(chain.ratchet_key);
+                let chain_key =
+                    RemoteChainKey::from_bytes_and_index(chain.chain_key, chain.chain_key_index);
+
+                ReceiverChain::new(ratchet_key, chain_key)
+            }
+        }
+
+        #[derive(Debug, Decode, Zeroize)]
+        #[zeroize(drop)]
+        struct MessageKey {
+            ratchet_key: [u8; 32],
+            message_key: [u8; 32],
+            index: u32,
+        }
+
+        impl From<&MessageKey> for RemoteMessageKey {
+            fn from(key: &MessageKey) -> Self {
+                RemoteMessageKey { key: key.message_key, index: key.index.into() }
+            }
+        }
+
+        #[derive(Decode)]
+        struct SessionPickle {
+            #[allow(dead_code)]
+            version: u32,
+            #[allow(dead_code)]
+            received_message: bool,
+            session_keys: SessionKeys,
+            root_key: [u8; 32],
+            sender_chains: Vec<SenderChain>,
+            receiver_chains: Vec<ReceivingChain>,
+            message_keys: Vec<MessageKey>,
+        }
+
+        impl Drop for SessionPickle {
+            fn drop(&mut self) {
+                self.root_key.zeroize();
+                self.sender_chains.zeroize();
+                self.receiver_chains.zeroize();
+                self.message_keys.zeroize();
+            }
+        }
+
+        let (pickle, _): (SessionPickle, usize) = decode_bincode(pickle)?;
+
+        let mut receiving_chains = ChainStore::new();
+
+        for chain in &pickle.receiver_chains {
+            receiving_chains.push(chain.into())
+        }
+
+        for key in &pickle.message_keys {
+            let ratchet_key = RemoteRatchetKey::from(Curve25519PublicKey::from(key.ratchet_key));
+
+            if let Some(receiving_chain) = receiving_chains.find_ratchet(&ratchet_key) {
+                receiving_chain.insert_message_key(key.into())
+            }
+        }
+
+        if let Some(chain) = pickle.sender_chains.get(0) {
+            let ratchet_key = RatchetKey::from(Curve25519SecretKey::from(chain.secret_ratchet_key));
+            let chain_key = ChainKey::from_bytes_and_index(chain.chain_key, chain.chain_key_index);
+
+            let root_key = RootKey::new(pickle.root_key);
+
+            let ratchet = Ratchet::new_with_ratchet_key(root_key, ratchet_key);
+            let sending_ratchet = DoubleRatchet::from_ratchet_and_chain_key(ratchet, chain_key);
+
+            Ok(Self {
+                session_keys: pickle.session_keys.clone(),
+                sending_ratchet,
+                receiving_chains,
+            })
+        } else if let Some(chain) = receiving_chains.get(0) {
+            let sending_ratchet =
+                DoubleRatchet::inactive(RemoteRootKey::new(pickle.root_key), chain.ratchet_key());
+
+            Ok(Self {
+                session_keys: pickle.session_keys.clone(),
+                sending_ratchet,
+                receiving_chains,
+            })
+        } else {
+            Err(crate::LibolmUnpickleError::InvalidSession)
+        }
+    }
+
     /// Create a [`Session`] object by unpickling a session pickle in libolm
     /// legacy pickle format.
     ///
@@ -299,119 +412,23 @@ impl Session {
         pickle: &str,
         pickle_key: &str,
     ) -> Result<Self, crate::LibolmUnpickleError> {
-        use chain_key::ChainKey;
-        use message_key::RemoteMessageKey;
-        use ratchet::{Ratchet, RatchetKey};
-        use root_key::RootKey;
-
         use crate::{
-            cipher::Cipher,
-            utilities::{read_curve_key, read_u32},
+            utilities::{decrypt_pickle, GetVersion},
+            LibolmUnpickleError,
         };
 
         const PICKLE_VERSION: u32 = 1;
 
-        let cipher = Cipher::new_pickle(pickle_key.as_ref());
-
-        let decoded = base64_decode(pickle)?;
-        let decrypted = cipher.decrypt_pickle(&decoded)?;
-        let mut cursor = Cursor::new(decrypted);
-
-        let version = read_u32(&mut cursor)?;
+        let mut decrypted = decrypt_pickle(pickle.as_ref(), pickle_key.as_ref())?;
+        let version = decrypted.get_version().ok_or(LibolmUnpickleError::MissingVersion)?;
 
         if version != PICKLE_VERSION {
-            Err(crate::LibolmUnpickleError::Version(PICKLE_VERSION, version))
+            Err(LibolmUnpickleError::Version(PICKLE_VERSION, version))
         } else {
-            // We skip fetching the received_message boolean, if there's a
-            // receiving chain, we must have received a message.
-            cursor.seek(SeekFrom::Current(1))?;
+            let session = Self::decode_libolm_pickle(&decrypted);
+            decrypted.zeroize();
 
-            let mut identity_key = [0u8; 32];
-            let mut base_key = [0u8; 32];
-            let mut one_time_key = [0u8; 32];
-
-            cursor.read_exact(&mut identity_key)?;
-            cursor.read_exact(&mut base_key)?;
-            cursor.read_exact(&mut one_time_key)?;
-
-            let identity_key = Curve25519PublicKey::from(identity_key);
-            let base_key = Curve25519PublicKey::from(base_key);
-            let one_time_key = Curve25519PublicKey::from(one_time_key);
-
-            let session_keys = SessionKeys { identity_key, base_key, one_time_key };
-
-            let mut root_key = [0u8; 32];
-            cursor.read_exact(&mut root_key)?;
-
-            let sender_chain_count = read_u32(&mut cursor)?;
-
-            let sending_ratchet = if sender_chain_count == 1 {
-                let mut chain_key = [0u8; 32];
-
-                let ratchet_key = read_curve_key(&mut cursor)?;
-                cursor.read_exact(&mut chain_key)?;
-                let chain_key_index = read_u32(&mut cursor)?;
-
-                let ratchet_key = RatchetKey::from(ratchet_key);
-                let chain_key = ChainKey::from_bytes_and_index(chain_key, chain_key_index);
-
-                let root_key = RootKey::new(root_key);
-
-                let ratchet = Ratchet::new_with_ratchet_key(root_key, ratchet_key);
-                Some(DoubleRatchet::from_ratchet_and_chain_key(ratchet, chain_key))
-            } else {
-                None
-            };
-
-            let receiving_chain_count = read_u32(&mut cursor)?;
-
-            let mut receiving_chains = ChainStore::new();
-
-            for _ in 0..receiving_chain_count {
-                let mut ratchet_key = [0u8; 32];
-                let mut chain_key = [0u8; 32];
-
-                cursor.read_exact(&mut ratchet_key)?;
-                cursor.read_exact(&mut chain_key)?;
-                let chain_key_index = read_u32(&mut cursor)?;
-
-                let ratchet_key = RemoteRatchetKey::from(ratchet_key);
-                let chain_key = RemoteChainKey::from_bytes_and_index(chain_key, chain_key_index);
-
-                let receiving_chain = ReceiverChain::new(ratchet_key, chain_key);
-
-                receiving_chains.push(receiving_chain);
-            }
-
-            let message_key_count = read_u32(&mut cursor)?;
-
-            for _ in 0..message_key_count {
-                let mut ratchet_key = [0u8; 32];
-                let mut message_key = [0u8; 32];
-
-                cursor.read_exact(&mut ratchet_key)?;
-                cursor.read_exact(&mut message_key)?;
-
-                let index = read_u32(&mut cursor)?.into();
-                let ratchet_key = RemoteRatchetKey::from(ratchet_key);
-
-                let message_key = RemoteMessageKey { key: message_key, index };
-
-                if let Some(receiving_chain) = receiving_chains.find_ratchet(&ratchet_key) {
-                    receiving_chain.insert_message_key(message_key)
-                }
-            }
-
-            if let Some(sending_ratchet) = sending_ratchet {
-                Ok(Self { session_keys, sending_ratchet, receiving_chains })
-            } else if let Some(chain) = receiving_chains.get(0) {
-                let sending_ratchet =
-                    DoubleRatchet::inactive(RemoteRootKey::new(root_key), chain.ratchet_key());
-
-                Ok(Self { session_keys, sending_ratchet, receiving_chains })
-            } else {
-                Err(crate::LibolmUnpickleError::InvalidSession)
-            }
+            session
         }
     }
 }
@@ -502,8 +519,8 @@ mod test {
             .parsed_one_time_keys()
             .curve25519()
             .values()
-            .cloned()
             .next()
+            .cloned()
             .expect("Couldn't find a one-time key");
 
         let identity_keys = bob.parsed_identity_keys();

--- a/src/olm/session/ratchet.rs
+++ b/src/olm/session/ratchet.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bincode::Decode;
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use x25519_dalek::{SharedSecret, StaticSecret as Curve25519SecretKey};
@@ -29,7 +30,7 @@ pub(super) struct RatchetKey(Curve25519SecretKey);
 #[derive(Debug, PartialEq)]
 pub(super) struct RatchetPublicKey(Curve25519PublicKey);
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Serialize, Deserialize, Decode)]
 #[serde(transparent)]
 pub struct RemoteRatchetKey(Curve25519PublicKey);
 

--- a/src/olm/session/root_key.rs
+++ b/src/olm/session/root_key.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bincode::Decode;
 use hkdf::Hkdf;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -24,7 +25,7 @@ use super::{
 
 const ADVANCEMENT_SEED: &[u8; 11] = b"OLM_RATCHET";
 
-#[derive(Serialize, Deserialize, Zeroize, Clone)]
+#[derive(Serialize, Deserialize, Zeroize, Clone, Decode)]
 #[serde(transparent)]
 pub(crate) struct RootKey {
     pub key: [u8; 32],

--- a/src/olm/session_keys.rs
+++ b/src/olm/session_keys.rs
@@ -13,12 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bincode::Decode;
 use serde::{Deserialize, Serialize};
 
 use crate::Curve25519PublicKey;
 
 /// The set of keys that were used to establish the Olm Session,
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Decode)]
 pub(crate) struct SessionKeys {
     pub(crate) identity_key: Curve25519PublicKey,
     pub(crate) base_key: Curve25519PublicKey,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -16,7 +16,7 @@ mod curve25519;
 mod ed25519;
 
 pub use curve25519::{Curve25519KeyError, Curve25519PublicKey};
-pub(crate) use curve25519::{Curve25519Keypair, Curve25519KeypairPickle};
+pub(crate) use curve25519::{Curve25519Keypair, Curve25519KeypairPickle, Curve25519SecretKey};
 pub(crate) use ed25519::{
     Ed25519Keypair, Ed25519KeypairPickle, Ed25519KeypairUnpicklingError, Ed25519Signature,
 };


### PR DESCRIPTION
This PR switches towards using the bincode crate to decode libolm pickles. This requires a bincode patch, since bincode encodes slice lengths as u64 while libolm as u32.