### PR TITLE
Add and expose an ed25519 secret key type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,8 @@ pub mod olm;
 pub mod sas;
 
 pub use types::{
-    Curve25519PublicKey, Ed25519PublicKey, Ed25519Signature, KeyId, PublicKeyError, SignatureError,
+    Curve25519PublicKey, Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature, KeyError, KeyId,
+    SignatureError,
 };
 
 #[cfg(feature = "libolm-compat")]
@@ -50,7 +51,7 @@ pub enum LibolmUnpickleError {
     #[error("The pickle couldn't be decrypted: {0}")]
     Decryption(#[from] crate::cipher::DecryptionError),
     #[error("The pickle contained an invalid ed25519 public key {0}")]
-    PublicKey(#[from] PublicKeyError),
+    PublicKey(#[from] KeyError),
     #[error("The pickle didn't contain a valid Olm session")]
     InvalidSession,
     #[error(transparent)]
@@ -66,7 +67,7 @@ pub enum DecodeError {
     #[error("The message didn't have a valid version, expected {0}, got {1}")]
     InvalidVersion(u8, u8),
     #[error("The message contained an invalid public key: {0}")]
-    InvalidKey(#[from] PublicKeyError),
+    InvalidKey(#[from] KeyError),
     #[error("The message contained a MAC with an invalid size, expected {0}, got {1}")]
     InvalidMacLength(usize, usize),
     #[error("The message contained an invalid Signature: {0}")]

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -48,7 +48,7 @@ pub enum SessionCreationError {
     #[error("The signature on the session key was invalid: {0}")]
     Signature(#[from] SignatureError),
     #[error("The public key of session was invalid: {0}")]
-    PublicKey(#[from] crate::PublicKeyError),
+    PublicKey(#[from] crate::KeyError),
 }
 
 #[derive(Debug, Error)]

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -107,11 +107,11 @@ impl Account {
 
     /// Get the IdentityKeys of this Account
     pub fn identity_keys(&self) -> IdentityKeys {
-        IdentityKeys { ed25519: *self.ed25519_key(), curve25519: *self.curve25519_key() }
+        IdentityKeys { ed25519: self.ed25519_key(), curve25519: *self.curve25519_key() }
     }
 
     /// Get a reference to the account's public Ed25519 key
-    pub fn ed25519_key(&self) -> &Ed25519PublicKey {
+    pub fn ed25519_key(&self) -> Ed25519PublicKey {
         self.signing_key.public_key()
     }
 

--- a/src/sas.rs
+++ b/src/sas.rs
@@ -60,7 +60,7 @@ use x25519_dalek::{EphemeralSecret, SharedSecret};
 
 use crate::{
     utilities::{base64_decode, base64_encode},
-    Curve25519PublicKey, PublicKeyError,
+    Curve25519PublicKey, KeyError,
 };
 
 type HmacSha256Key = [u8; 32];
@@ -249,13 +249,13 @@ impl Sas {
     pub fn diffie_hellman(
         self,
         their_public_key: Curve25519PublicKey,
-    ) -> Result<EstablishedSas, PublicKeyError> {
+    ) -> Result<EstablishedSas, KeyError> {
         let shared_secret = self.secret_key.diffie_hellman(&their_public_key.inner);
 
         if shared_secret.was_contributory() {
             Ok(EstablishedSas { shared_secret, our_public_key: self.public_key, their_public_key })
         } else {
-            Err(PublicKeyError::NonContributoryKey)
+            Err(KeyError::NonContributoryKey)
         }
     }
 
@@ -267,7 +267,7 @@ impl Sas {
     pub fn diffie_hellman_with_raw(
         self,
         other_public_key: &str,
-    ) -> Result<EstablishedSas, PublicKeyError> {
+    ) -> Result<EstablishedSas, KeyError> {
         let other_public_key = Curve25519PublicKey::from_base64(other_public_key)?;
         self.diffie_hellman(other_public_key)
     }

--- a/src/types/curve25519.rs
+++ b/src/types/curve25519.rs
@@ -18,7 +18,7 @@ pub use x25519_dalek::StaticSecret as Curve25519SecretKey;
 use x25519_dalek::{EphemeralSecret, PublicKey, ReusableSecret};
 use zeroize::Zeroize;
 
-use super::PublicKeyError;
+use super::KeyError;
 use crate::utilities::{base64_decode, base64_encode};
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -107,13 +107,13 @@ impl Curve25519PublicKey {
 
     /// Instantiate a Curve25519 public key from an unpadded base64
     /// representation.
-    pub fn from_base64(base64_key: &str) -> Result<Curve25519PublicKey, PublicKeyError> {
+    pub fn from_base64(base64_key: &str) -> Result<Curve25519PublicKey, KeyError> {
         let key = base64_decode(base64_key)?;
         Self::from_slice(&key)
     }
 
     /// Try to create a `Curve25519PublicKey` from a slice of bytes.
-    pub fn from_slice(slice: &[u8]) -> Result<Curve25519PublicKey, PublicKeyError> {
+    pub fn from_slice(slice: &[u8]) -> Result<Curve25519PublicKey, KeyError> {
         let key_len = slice.len();
 
         if key_len == Self::LENGTH {
@@ -122,7 +122,7 @@ impl Curve25519PublicKey {
 
             Ok(Self::from(key))
         } else {
-            Err(PublicKeyError::InvalidKeyLength(key_len))
+            Err(KeyError::InvalidKeyLength(key_len))
         }
     }
 
@@ -190,26 +190,26 @@ impl From<Curve25519Keypair> for Curve25519KeypairPickle {
 #[cfg(test)]
 mod tests {
     use super::Curve25519PublicKey;
-    use crate::{utilities::DecodeError, PublicKeyError};
+    use crate::{utilities::DecodeError, KeyError};
 
     #[test]
     fn decoding_invalid_base64_fails() {
         let base64_payload = "a";
         assert!(matches!(
             Curve25519PublicKey::from_base64(base64_payload),
-            Err(PublicKeyError::Base64Error(DecodeError::InvalidLength))
+            Err(KeyError::Base64Error(DecodeError::InvalidLength))
         ));
 
         let base64_payload = "a ";
         assert!(matches!(
             Curve25519PublicKey::from_base64(base64_payload),
-            Err(PublicKeyError::Base64Error(DecodeError::InvalidByte(..)))
+            Err(KeyError::Base64Error(DecodeError::InvalidByte(..)))
         ));
 
         let base64_payload = "aZ";
         assert!(matches!(
             Curve25519PublicKey::from_base64(base64_payload),
-            Err(PublicKeyError::Base64Error(DecodeError::InvalidLastSymbol(..)))
+            Err(KeyError::Base64Error(DecodeError::InvalidLastSymbol(..)))
         ));
     }
 
@@ -218,7 +218,7 @@ mod tests {
         let base64_payload = "aaaa";
         assert!(matches!(
             Curve25519PublicKey::from_base64(base64_payload),
-            Err(PublicKeyError::InvalidKeyLength(..))
+            Err(KeyError::InvalidKeyLength(..))
         ));
     }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -20,7 +20,7 @@ pub use curve25519::Curve25519PublicKey;
 pub(crate) use curve25519::Curve25519SecretKey;
 pub(crate) use curve25519::{Curve25519Keypair, Curve25519KeypairPickle};
 pub(crate) use ed25519::{Ed25519Keypair, Ed25519KeypairPickle, Ed25519KeypairUnpicklingError};
-pub use ed25519::{Ed25519PublicKey, Ed25519Signature, SignatureError};
+pub use ed25519::{Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature, SignatureError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -40,9 +40,9 @@ impl KeyId {
 }
 
 /// Error type describing failures that can happen when we try decode or use a
-/// public key.
+/// cryptographic key.
 #[derive(Error, Debug)]
-pub enum PublicKeyError {
+pub enum KeyError {
     #[error("Failed decoding a public key from base64: {}", .0)]
     Base64Error(#[from] base64::DecodeError),
     #[error("Failed decoding curve25519 key from base64: \


### PR DESCRIPTION
This type is useful if users need to create a separate identity to sign messages with, i.e. it's used in cross signing in Matrix land.
