### PR TITLE
Update pre-commit hooks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,13 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 
--   repo: local
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
     hooks:
       - id: fmt
         name: fmt
@@ -21,6 +22,8 @@ repos:
         entry: cargo clippy --all-targets --all
         pass_filenames: false
 
+-   repo: local
+    hooks:
       - id: test
         name: test
         language: system


### PR DESCRIPTION
Without this change, the clippy hook isn't executed correctly.
