### PR TITLE
Put secret keys behind a box to avoid unwanted memcpys

### DIFF
--- a/src/olm/account/fallback_keys.rs
+++ b/src/olm/account/fallback_keys.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand::thread_rng;
 use serde::{Deserialize, Serialize};
-use x25519_dalek::StaticSecret as Curve25519SecretKey;
-use zeroize::Zeroize;
 
-use crate::{types::KeyId, Curve25519PublicKey};
+use crate::{
+    types::{Curve25519SecretKey, KeyId},
+    Curve25519PublicKey,
+};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub(super) struct FallbackKey {
@@ -28,8 +28,7 @@ pub(super) struct FallbackKey {
 
 impl FallbackKey {
     fn new(key_id: KeyId) -> Self {
-        let mut rng = thread_rng();
-        let key = Curve25519SecretKey::new(&mut rng);
+        let key = Curve25519SecretKey::new();
 
         Self { key_id, key, published: false }
     }
@@ -52,12 +51,6 @@ impl FallbackKey {
 
     pub fn published(&self) -> bool {
         self.published
-    }
-}
-
-impl Zeroize for FallbackKey {
-    fn zeroize(&mut self) {
-        self.key.zeroize();
     }
 }
 

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use x25519_dalek::{ReusableSecret, StaticSecret as Curve25519SecretKey};
+use x25519_dalek::ReusableSecret;
 use zeroize::Zeroize;
 
 use self::{
@@ -35,8 +35,8 @@ use super::{
 };
 use crate::{
     types::{
-        Curve25519Keypair, Curve25519KeypairPickle, Curve25519PublicKey, Ed25519Keypair,
-        Ed25519KeypairPickle, Ed25519PublicKey, KeyId,
+        Curve25519Keypair, Curve25519KeypairPickle, Curve25519PublicKey, Curve25519SecretKey,
+        Ed25519Keypair, Ed25519KeypairPickle, Ed25519PublicKey, KeyId,
     },
     utilities::{base64_encode, pickle, unpickle, DecodeSecret},
     DecodeError, PickleError,
@@ -378,8 +378,7 @@ impl Account {
             fn from(key: &OneTimeKey) -> Self {
                 FallbackKey {
                     key_id: KeyId(key.key_id.into()),
-                    // XXX: Passing in secret array as value.
-                    key: Curve25519SecretKey::from(*key.private_key),
+                    key: Curve25519SecretKey::from_slice(&key.private_key),
                     published: key.published,
                 }
             }
@@ -459,8 +458,7 @@ impl Account {
                 let mut max_key_id = 0;
 
                 for key in &pickle.one_time_keys {
-                    // XXX: Passing in secret array as value.
-                    let secret_key = Curve25519SecretKey::from(*key.private_key);
+                    let secret_key = Curve25519SecretKey::from_slice(&key.private_key);
                     let key_id = KeyId(key.key_id.into());
                     one_time_keys.insert_secret_key(key_id, secret_key, key.published);
 

--- a/src/olm/account/one_time_keys.rs
+++ b/src/olm/account/one_time_keys.rs
@@ -14,12 +14,13 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use rand::thread_rng;
 use serde::{Deserialize, Serialize};
-use x25519_dalek::StaticSecret as Curve25519SecretKey;
 
 use super::PUBLIC_MAX_ONE_TIME_KEYS;
-use crate::{types::KeyId, Curve25519PublicKey};
+use crate::{
+    types::{Curve25519SecretKey, KeyId},
+    Curve25519PublicKey,
+};
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(from = "OneTimeKeysPickle")]
@@ -89,11 +90,9 @@ impl OneTimeKeys {
     }
 
     pub fn generate(&mut self, count: usize) {
-        let mut rng = thread_rng();
-
         for _ in 0..count {
             let key_id = KeyId(self.key_id);
-            let key = Curve25519SecretKey::new(&mut rng);
+            let key = Curve25519SecretKey::new();
 
             self.insert_secret_key(key_id, key, false);
 

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -424,8 +424,9 @@ impl Session {
 
                 if let Some(chain) = pickle.sender_chains.get(0) {
                     // XXX: Passing in secret array as value.
-                    let ratchet_key =
-                        RatchetKey::from(Curve25519SecretKey::from(*chain.secret_ratchet_key));
+                    let ratchet_key = RatchetKey::from(Curve25519SecretKey::from_slice(
+                        chain.secret_ratchet_key.as_ref(),
+                    ));
                     let chain_key = ChainKey::from_bytes_and_index(
                         chain.chain_key.clone(),
                         chain.chain_key_index,

--- a/src/olm/session/ratchet.rs
+++ b/src/olm/session/ratchet.rs
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use rand::thread_rng;
 use serde::{Deserialize, Serialize};
-use x25519_dalek::{SharedSecret, StaticSecret as Curve25519SecretKey};
+use x25519_dalek::SharedSecret;
 
 use super::{
     chain_key::RemoteChainKey,
     root_key::{RemoteRootKey, RootKey},
 };
-use crate::Curve25519PublicKey;
+use crate::{types::Curve25519SecretKey, Curve25519PublicKey};
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(transparent)]
@@ -46,12 +45,11 @@ impl crate::utilities::Decode for RemoteRatchetKey {
 
 impl RatchetKey {
     pub fn new() -> Self {
-        let rng = thread_rng();
-        Self(Curve25519SecretKey::new(rng))
+        Self(Curve25519SecretKey::new())
     }
 
     pub fn diffie_hellman(&self, other: &RemoteRatchetKey) -> SharedSecret {
-        self.0.diffie_hellman(&other.0.inner)
+        self.0.diffie_hellman(&other.0)
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -16,9 +16,7 @@ mod curve25519;
 mod ed25519;
 
 pub use curve25519::Curve25519PublicKey;
-#[cfg(feature = "libolm-compat")]
-pub(crate) use curve25519::Curve25519SecretKey;
-pub(crate) use curve25519::{Curve25519Keypair, Curve25519KeypairPickle};
+pub(crate) use curve25519::{Curve25519Keypair, Curve25519KeypairPickle, Curve25519SecretKey};
 pub(crate) use ed25519::{Ed25519Keypair, Ed25519KeypairPickle};
 pub use ed25519::{Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature, SignatureError};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
- refactor(types): Put the curve25519 secret key type behind a box
- refactor(types): Put the ed25519 secret key types behind a box
