### PR TITLE
Enable the rust-2018-idioms lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,8 @@
     unsafe_op_in_unsafe_fn,
     unused_extern_crates,
     unused_import_braces,
-    unused_qualifications
+    unused_qualifications,
+    rust_2018_idioms
 )]
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/src/megolm/ratchet.rs
+++ b/src/megolm/ratchet.rs
@@ -147,7 +147,7 @@ impl Ratchet {
         &self.inner.0
     }
 
-    fn as_parts(&mut self) -> RatchetParts {
+    fn as_parts(&mut self) -> RatchetParts<'_> {
         let (top, bottom) = self.inner.0.split_at_mut(64);
 
         let (r_0, r_1) = top.split_at_mut(32);


### PR DESCRIPTION
This fixes a small issue where it wasn't obvious that our RatchetParts
is using borrowing.
