### PR TITLE
Expose some lower level APIs behind a `low-level` feature flag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ default = ["libolm-compat"]
 js = ["rand/wasm-bindgen"]
 strict-signatures = []
 libolm-compat = []
+# The low-level-api feature exposes extra APIs that are only useful in advanced
+# use cases and require extra care to use.
+low-level-api = []
 
 [dependencies]
 aes = "0.7.5"

--- a/README.md
+++ b/README.md
@@ -212,3 +212,14 @@ earlier state. This preserves forward secrecy.
 
 A detailed technical specification can be found at
 <https://gitlab.matrix.org/matrix-org/olm/-/blob/master/docs/megolm.md>.
+
+
+# Low level API
+
+Vodozemac exposes some lower level structs and functions that are only useful in
+very advanced use cases. These are exposed via the `low-level-api` feature,
+which is disabled by default. These should *not* be needed by the vast majority
+of users.
+
+Extreme care must be taken when using such APIs, as incorrect usage can lead to
+broken sessions.

--- a/src/cipher/mod.rs
+++ b/src/cipher/mod.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 type Aes256Cbc = Cbc<Aes256, Pkcs7>;
 type HmacSha256 = Hmac<Sha256>;
 
-pub(crate) struct Mac([u8; 32]);
+pub struct Mac([u8; 32]);
 
 impl Mac {
     pub const TRUNCATED_LEN: usize = 8;
@@ -49,7 +49,7 @@ pub enum DecryptionError {
     MacMissing,
 }
 
-pub(super) struct Cipher {
+pub struct Cipher {
     keys: CipherKeys,
 }
 

--- a/src/hazmat/mod.rs
+++ b/src/hazmat/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 The Matrix.org Foundation C.I.C.
+// Copyright 2022 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/hazmat/mod.rs
+++ b/src/hazmat/mod.rs
@@ -1,5 +1,4 @@
 // Copyright 2021 The Matrix.org Foundation C.I.C.
-// Copyright 2021 Damir Jelić, Denis Kasak
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! An implementation of the Olm ratchet.
+//! ⚠️ Low-level "hazmat" functions.
+//!
+//! This module contains low level APIs that should *not* be used or needed by
+//! most users.
+//!
+//! These functions are exported to aid very advanced use cases.
 
-mod account;
-mod messages;
-pub(crate) mod session;
-mod session_keys;
-mod shared_secret;
+#![cfg(feature = "low-level-api")]
 
-pub use account::{Account, AccountPickle, IdentityKeys, InboundCreationResult};
-pub use messages::{Message, MessageType, OlmMessage, PreKeyMessage};
-pub use session::{ratchet::RatchetPublicKey, DecryptionError, Session, SessionPickle};
-pub use session_keys::SessionKeys;
+pub mod olm;
+
+pub use crate::cipher::{Cipher, Mac};

--- a/src/hazmat/olm.rs
+++ b/src/hazmat/olm.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 The Matrix.org Foundation C.I.C.
+// Copyright 2022 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/hazmat/olm.rs
+++ b/src/hazmat/olm.rs
@@ -1,5 +1,4 @@
 // Copyright 2021 The Matrix.org Foundation C.I.C.
-// Copyright 2021 Damir Jelić, Denis Kasak
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,15 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! An implementation of the Olm ratchet.
+//! Hazmat functions related to OLM.
 
-mod account;
-mod messages;
-pub(crate) mod session;
-mod session_keys;
-mod shared_secret;
-
-pub use account::{Account, AccountPickle, IdentityKeys, InboundCreationResult};
-pub use messages::{Message, MessageType, OlmMessage, PreKeyMessage};
-pub use session::{ratchet::RatchetPublicKey, DecryptionError, Session, SessionPickle};
-pub use session_keys::SessionKeys;
+pub use crate::olm::session::message_key::MessageKey;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,8 @@ pub mod sas;
 #[cfg(feature = "low-level-api")]
 pub use cipher::{Cipher, Mac};
 pub use types::{
-    Curve25519PublicKey, Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature, KeyError, KeyId,
-    SignatureError,
+    Curve25519PublicKey, Ed25519Keypair, Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature,
+    KeyError, KeyId, SignatureError,
 };
 
 #[derive(Debug, thiserror::Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@ pub mod megolm;
 pub mod olm;
 pub mod sas;
 
+#[cfg(feature = "low-level-api")]
+pub use cipher::{Cipher, Mac};
 pub use types::{
     Curve25519PublicKey, Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature, KeyError, KeyId,
     SignatureError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,12 +32,11 @@ mod cipher;
 mod types;
 mod utilities;
 
+pub mod hazmat;
 pub mod megolm;
 pub mod olm;
 pub mod sas;
 
-#[cfg(feature = "low-level-api")]
-pub use cipher::{Cipher, Mac};
 pub use types::{
     Curve25519PublicKey, Ed25519Keypair, Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature,
     KeyError, KeyId, SignatureError,

--- a/src/megolm/group_session.rs
+++ b/src/megolm/group_session.rs
@@ -80,7 +80,7 @@ impl GroupSession {
     pub fn encrypt(&mut self, plaintext: &str) -> MegolmMessage {
         let cipher = Cipher::new_megolm(self.ratchet.as_bytes());
 
-        let message = MegolmMessage::encrypt(
+        let message = MegolmMessage::encrypt_private(
             self.message_index(),
             &cipher,
             &self.signing_key,

--- a/src/megolm/group_session.rs
+++ b/src/megolm/group_session.rs
@@ -80,14 +80,12 @@ impl GroupSession {
     pub fn encrypt(&mut self, plaintext: &str) -> MegolmMessage {
         let cipher = Cipher::new_megolm(self.ratchet.as_bytes());
 
-        let ciphertext = cipher.encrypt(plaintext.as_ref());
-        let mut message = MegolmMessage::new(ciphertext, self.message_index());
-
-        let mac = cipher.mac(&message.to_mac_bytes());
-        message.mac = mac.truncate();
-
-        let signature = self.signing_key.sign(&message.to_signature_bytes());
-        message.signature = signature;
+        let message = MegolmMessage::encrypt(
+            self.message_index(),
+            &cipher,
+            &self.signing_key,
+            plaintext.as_ref(),
+        );
 
         self.ratchet.advance();
 

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -174,9 +174,9 @@ impl InboundGroupSession {
         }
     }
 
-    #[cfg(feature = "low-level-api")]
     /// Returns a copy of the [`Cipher`] at the given message index, without
     /// advancing the internal ratchets.
+    #[cfg(feature = "low-level-api")]
     pub fn get_cipher_at(&self, message_index: u32) -> Option<Cipher> {
         if self.initial_ratchet.index() >= message_index {
             let mut ratchet = self.initial_ratchet.clone();

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -174,6 +174,19 @@ impl InboundGroupSession {
         }
     }
 
+    #[cfg(feature = "low-level-api")]
+    pub fn get_cipher_at(&self, message_index: u32) -> Option<Cipher> {
+        if self.initial_ratchet.index() >= message_index {
+            let mut ratchet = self.initial_ratchet.clone();
+            if self.initial_ratchet.index() > message_index {
+                ratchet.advance_to(message_index);
+            }
+            Some(Cipher::new_megolm(ratchet.as_bytes()))
+        } else {
+            None
+        }
+    }
+
     fn find_ratchet(&mut self, message_index: u32) -> Option<&Ratchet> {
         if self.initial_ratchet.index() == message_index {
             Some(&self.initial_ratchet)

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -175,6 +175,8 @@ impl InboundGroupSession {
     }
 
     #[cfg(feature = "low-level-api")]
+    /// Returns a copy of the [`Cipher`] at the given message index, without
+    /// advancing the internal ratchets.
     pub fn get_cipher_at(&self, message_index: u32) -> Option<Cipher> {
         if self.initial_ratchet.index() >= message_index {
             let mut ratchet = self.initial_ratchet.clone();

--- a/src/megolm/message.rs
+++ b/src/megolm/message.rs
@@ -20,8 +20,10 @@ use crate::{
     cipher::{Cipher, Mac},
     types::{Ed25519Keypair, Ed25519Signature},
     utilities::{base64_decode, base64_encode, VarInt},
-    DecodeError, Ed25519PublicKey, SignatureError,
+    DecodeError,
 };
+#[cfg(feature = "low-level-api")]
+use crate::{Ed25519PublicKey, SignatureError};
 
 const VERSION: u8 = 3;
 

--- a/src/megolm/message.rs
+++ b/src/megolm/message.rs
@@ -20,7 +20,7 @@ use crate::{
     cipher::Mac,
     types::Ed25519Signature,
     utilities::{base64_decode, base64_encode, VarInt},
-    DecodeError,
+    DecodeError, Ed25519PublicKey, SignatureError,
 };
 
 const VERSION: u8 = 3;
@@ -102,6 +102,21 @@ impl MegolmMessage {
     /// the resulting byte array as a string using base64 encoding.
     pub fn to_base64(&self) -> String {
         base64_encode(self.to_bytes())
+    }
+
+    #[cfg(feature = "low-level-api")]
+    /// Set the signature of the message, verifying that the signature matches
+    /// the signing key.
+    pub fn add_signature(
+        &mut self,
+        signature: Ed25519Signature,
+        signing_key: Ed25519PublicKey,
+    ) -> Result<(), SignatureError> {
+        signing_key.verify(&self.to_signature_bytes(), &signature)?;
+
+        self.signature = signature;
+
+        Ok(())
     }
 
     fn encode_message(&self) -> Vec<u8> {

--- a/src/megolm/message.rs
+++ b/src/megolm/message.rs
@@ -116,9 +116,9 @@ impl MegolmMessage {
         base64_encode(self.to_bytes())
     }
 
-    #[cfg(feature = "low-level-api")]
     /// Set the signature of the message, verifying that the signature matches
     /// the signing key.
+    #[cfg(feature = "low-level-api")]
     pub fn add_signature(
         &mut self,
         signature: Ed25519Signature,

--- a/src/megolm/message.rs
+++ b/src/megolm/message.rs
@@ -51,6 +51,16 @@ impl MegolmMessage {
         self.message_index
     }
 
+    /// Get the megolm message's mac.
+    pub fn mac(&self) -> [u8; Mac::TRUNCATED_LEN] {
+        self.mac
+    }
+
+    /// Get a reference to the megolm message's signature.
+    pub fn signature(&self) -> &Ed25519Signature {
+        &self.signature
+    }
+
     /// Try to decode the given byte slice as a [`MegolmMessage`].
     ///
     /// The expected format of the byte array is described in the

--- a/src/megolm/message.rs
+++ b/src/megolm/message.rs
@@ -141,7 +141,19 @@ impl MegolmMessage {
     }
 
     /// Create a new [`MegolmMessage`] with the given plaintext and keys.
+    #[cfg(feature = "low-level-api")]
     pub fn encrypt(
+        message_index: u32,
+        cipher: &Cipher,
+        signing_key: &Ed25519Keypair,
+        plaintext: &[u8],
+    ) -> MegolmMessage {
+        MegolmMessage::encrypt_private(message_index, cipher, signing_key, plaintext)
+    }
+
+    /// Implementation of [`MegolmMessage::encrypt`] that is used by rest of the
+    /// crate.
+    pub(super) fn encrypt_private(
         message_index: u32,
         cipher: &Cipher,
         signing_key: &Ed25519Keypair,

--- a/src/olm/messages/pre_key.rs
+++ b/src/olm/messages/pre_key.rs
@@ -134,6 +134,7 @@ impl PreKeyMessage {
     }
 
     #[cfg(feature = "low-level-api")]
+    /// Create a new pre-key message from the session keys and standard message.
     pub fn wrap(session_keys: SessionKeys, message: Message) -> Self {
         PreKeyMessage::new(session_keys, message)
     }

--- a/src/olm/messages/pre_key.rs
+++ b/src/olm/messages/pre_key.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use super::Message;
 use crate::{
+    olm::SessionKeys,
     utilities::{base64_decode, base64_encode},
     Curve25519PublicKey, DecodeError,
 };
@@ -132,13 +133,18 @@ impl PreKeyMessage {
         base64_encode(self.to_bytes())
     }
 
-    pub(crate) fn new(
-        one_time_key: Curve25519PublicKey,
-        base_key: Curve25519PublicKey,
-        identity_key: Curve25519PublicKey,
-        message: Message,
-    ) -> Self {
-        Self { one_time_key, base_key, identity_key, message }
+    #[cfg(feature = "low-level-api")]
+    pub fn wrap(session_keys: SessionKeys, message: Message) -> Self {
+        PreKeyMessage::new(session_keys, message)
+    }
+
+    pub(crate) fn new(session_keys: SessionKeys, message: Message) -> Self {
+        Self {
+            one_time_key: session_keys.one_time_key,
+            base_key: session_keys.base_key,
+            identity_key: session_keys.identity_key,
+            message,
+        }
     }
 }
 

--- a/src/olm/messages/pre_key.rs
+++ b/src/olm/messages/pre_key.rs
@@ -133,8 +133,8 @@ impl PreKeyMessage {
         base64_encode(self.to_bytes())
     }
 
-    #[cfg(feature = "low-level-api")]
     /// Create a new pre-key message from the session keys and standard message.
+    #[cfg(feature = "low-level-api")]
     pub fn wrap(session_keys: SessionKeys, message: Message) -> Self {
         PreKeyMessage::new(session_keys, message)
     }

--- a/src/olm/mod.rs
+++ b/src/olm/mod.rs
@@ -23,4 +23,5 @@ mod shared_secret;
 
 pub use account::{Account, AccountPickle, IdentityKeys, InboundCreationResult};
 pub use messages::{Message, MessageType, OlmMessage, PreKeyMessage};
-pub use session::{DecryptionError, Session, SessionPickle};
+pub use session::{message_key::MessageKey, DecryptionError, Session, SessionPickle};
+pub use session_keys::SessionKeys;

--- a/src/olm/mod.rs
+++ b/src/olm/mod.rs
@@ -22,8 +22,8 @@ mod session_keys;
 mod shared_secret;
 
 pub use account::{Account, AccountPickle, IdentityKeys, InboundCreationResult};
+#[cfg(features = "low-level-api")]
+pub use message_key::MessageKey;
 pub use messages::{Message, MessageType, OlmMessage, PreKeyMessage};
-pub use session::{
-    message_key::MessageKey, ratchet::RatchetPublicKey, DecryptionError, Session, SessionPickle,
-};
+pub use session::{ratchet::RatchetPublicKey, DecryptionError, Session, SessionPickle};
 pub use session_keys::SessionKeys;

--- a/src/olm/mod.rs
+++ b/src/olm/mod.rs
@@ -23,5 +23,7 @@ mod shared_secret;
 
 pub use account::{Account, AccountPickle, IdentityKeys, InboundCreationResult};
 pub use messages::{Message, MessageType, OlmMessage, PreKeyMessage};
-pub use session::{message_key::MessageKey, DecryptionError, Session, SessionPickle};
+pub use session::{
+    message_key::MessageKey, ratchet::RatchetPublicKey, DecryptionError, Session, SessionPickle,
+};
 pub use session_keys::SessionKeys;

--- a/src/olm/session/message_key.rs
+++ b/src/olm/session/message_key.rs
@@ -66,10 +66,10 @@ impl MessageKey {
         self.key.as_ref()
     }
 
-    /// Get a reference to the message key's ratchet key.
+    /// Get the message key's ratchet key.
     #[cfg(feature = "low-level-api")]
-    pub fn ratchet_key(&self) -> &RatchetPublicKey {
-        &self.ratchet_key
+    pub fn ratchet_key(&self) -> RatchetPublicKey {
+        self.ratchet_key
     }
 
     /// Get the message key's index.

--- a/src/olm/session/message_key.rs
+++ b/src/olm/session/message_key.rs
@@ -43,6 +43,12 @@ impl Drop for RemoteMessageKey {
 }
 
 impl MessageKey {
+    #[cfg(feature = "low-level-api")]
+    pub fn new(key: Box<[u8; 32]>, ratchet_key: RatchetPublicKey, index: u64) -> Self {
+        Self { key, ratchet_key, index }
+    }
+
+    #[cfg(not(feature = "low-level-api"))]
     pub(super) fn new(key: Box<[u8; 32]>, ratchet_key: RatchetPublicKey, index: u64) -> Self {
         Self { key, ratchet_key, index }
     }
@@ -52,12 +58,27 @@ impl MessageKey {
 
         let ciphertext = cipher.encrypt(plaintext);
 
-        let mut message = Message::new(self.ratchet_key.0, self.index, ciphertext);
+        let mut message = Message::new(*self.ratchet_key.as_ref(), self.index, ciphertext);
 
         let mac = cipher.mac(&message.to_mac_bytes());
         message.mac = mac.truncate();
 
         message
+    }
+
+    /// Get a reference to the message key's key.
+    pub fn key(&self) -> &[u8; 32] {
+        self.key.as_ref()
+    }
+
+    /// Get a reference to the message key's ratchet key.
+    pub fn ratchet_key(&self) -> &RatchetPublicKey {
+        &self.ratchet_key
+    }
+
+    /// Get the message key's index.
+    pub fn index(&self) -> u64 {
+        self.index
     }
 }
 

--- a/src/olm/session/message_key.rs
+++ b/src/olm/session/message_key.rs
@@ -43,13 +43,7 @@ impl Drop for RemoteMessageKey {
 }
 
 impl MessageKey {
-    #[cfg(feature = "low-level-api")]
     pub fn new(key: Box<[u8; 32]>, ratchet_key: RatchetPublicKey, index: u64) -> Self {
-        Self { key, ratchet_key, index }
-    }
-
-    #[cfg(not(feature = "low-level-api"))]
-    pub(super) fn new(key: Box<[u8; 32]>, ratchet_key: RatchetPublicKey, index: u64) -> Self {
         Self { key, ratchet_key, index }
     }
 
@@ -67,16 +61,19 @@ impl MessageKey {
     }
 
     /// Get a reference to the message key's key.
+    #[cfg(feature = "low-level-api")]
     pub fn key(&self) -> &[u8; 32] {
         self.key.as_ref()
     }
 
     /// Get a reference to the message key's ratchet key.
+    #[cfg(feature = "low-level-api")]
     pub fn ratchet_key(&self) -> &RatchetPublicKey {
         &self.ratchet_key
     }
 
     /// Get the message key's index.
+    #[cfg(feature = "low-level-api")]
     pub fn index(&self) -> u64 {
         self.index
     }

--- a/src/olm/session/message_key.rs
+++ b/src/olm/session/message_key.rs
@@ -18,7 +18,7 @@ use zeroize::Zeroize;
 use super::{ratchet::RatchetPublicKey, DecryptionError};
 use crate::{cipher::Cipher, olm::messages::Message};
 
-pub(super) struct MessageKey {
+pub struct MessageKey {
     key: Box<[u8; 32]>,
     ratchet_key: RatchetPublicKey,
     index: u64,
@@ -43,7 +43,7 @@ impl Drop for RemoteMessageKey {
 }
 
 impl MessageKey {
-    pub fn new(key: Box<[u8; 32]>, ratchet_key: RatchetPublicKey, index: u64) -> Self {
+    pub(super) fn new(key: Box<[u8; 32]>, ratchet_key: RatchetPublicKey, index: u64) -> Self {
         Self { key, ratchet_key, index }
     }
 

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -33,12 +33,12 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 use zeroize::Zeroize;
 
-#[cfg(feature = "low-level-api")]
-use self::message_key::MessageKey;
 use super::{
     session_keys::SessionKeys,
     shared_secret::{RemoteShared3DHSecret, Shared3DHSecret},
 };
+#[cfg(feature = "low-level-api")]
+use crate::hazmat::olm::MessageKey;
 use crate::{
     olm::messages::{Message, OlmMessage, PreKeyMessage},
     utilities::{base64_encode, pickle, unpickle, DecodeSecret},

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -192,7 +192,10 @@ impl Session {
         base64_encode(digest)
     }
 
-    // Have we ever received and decrypted a message from the other side?
+    /// Have we ever received and decrypted a message from the other side?
+    ///
+    /// Used to decide if outgoing messages should be sent as normal or pre-key
+    /// messages.
     pub fn has_received_message(&self) -> bool {
         !self.receiving_chains.is_empty()
     }

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -222,7 +222,7 @@ impl Session {
 
     /// Get the [`MessageKey`] to encrypt the next message.
     ///
-    /// **Note**: This *must* be used to encrypt the next message.
+    /// **Note**: This *must* be used to encrypt the message.
     #[cfg(feature = "low-level-api")]
     pub fn next_message_key(&mut self) -> MessageKey {
         self.sending_ratchet.next_message_key()

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -192,7 +192,7 @@ impl Session {
     }
 
     // Have we ever received and decrypted a message from the other side?
-    fn has_received_message(&self) -> bool {
+    pub fn has_received_message(&self) -> bool {
         !self.receiving_chains.is_empty()
     }
 

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -225,7 +225,13 @@ impl Session {
 
     /// Get the [`MessageKey`] to encrypt the next message.
     ///
-    /// **Note**: This *must* be used to encrypt the message.
+    /// **Note**: Each key obtained in this way should be used to encrypt
+    /// a message and the message must then be sent to the recipient.
+    ///
+    /// Failing to do so will increase the number of out-of-order messages on
+    /// the recipient side. Given that a `Session` can only support a limited
+    /// number of out-of-order messages, this will eventually lead to
+    /// undecryptable messages.
     #[cfg(feature = "low-level-api")]
     pub fn next_message_key(&mut self) -> MessageKey {
         self.sending_ratchet.next_message_key()

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -16,7 +16,7 @@
 mod chain_key;
 mod double_ratchet;
 pub mod message_key;
-mod ratchet;
+pub mod ratchet;
 mod receiver_chain;
 mod root_key;
 

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -220,10 +220,10 @@ impl Session {
         self.session_keys
     }
 
-    #[cfg(feature = "low-level-api")]
     /// Get the [`MessageKey`] to encrypt the next message.
     ///
     /// **Note**: This *must* be used to encrypt the next message.
+    #[cfg(feature = "low-level-api")]
     pub fn next_message_key(&mut self) -> MessageKey {
         self.sending_ratchet.next_message_key()
     }

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -33,6 +33,7 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 use zeroize::Zeroize;
 
+#[cfg(feature = "low-level-api")]
 use self::message_key::MessageKey;
 use super::{
     session_keys::SessionKeys,

--- a/src/olm/session/ratchet.rs
+++ b/src/olm/session/ratchet.rs
@@ -25,8 +25,8 @@ use crate::{types::Curve25519SecretKey, Curve25519PublicKey};
 #[serde(transparent)]
 pub(super) struct RatchetKey(Curve25519SecretKey);
 
-#[derive(Debug, PartialEq)]
-pub(super) struct RatchetPublicKey(pub(super) Curve25519PublicKey);
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct RatchetPublicKey(Curve25519PublicKey);
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]

--- a/src/olm/session_keys.rs
+++ b/src/olm/session_keys.rs
@@ -18,11 +18,11 @@ use serde::{Deserialize, Serialize};
 use crate::Curve25519PublicKey;
 
 /// The set of keys that were used to establish the Olm Session,
-#[derive(Serialize, Deserialize, Clone)]
-pub(crate) struct SessionKeys {
-    pub(crate) identity_key: Curve25519PublicKey,
-    pub(crate) base_key: Curve25519PublicKey,
-    pub(crate) one_time_key: Curve25519PublicKey,
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct SessionKeys {
+    pub identity_key: Curve25519PublicKey,
+    pub base_key: Curve25519PublicKey,
+    pub one_time_key: Curve25519PublicKey,
 }
 
 #[cfg(feature = "libolm-compat")]

--- a/src/types/ed25519.rs
+++ b/src/types/ed25519.rs
@@ -37,7 +37,7 @@ pub enum SignatureError {
 #[derive(Deserialize, Serialize)]
 #[serde(try_from = "Ed25519KeypairPickle")]
 #[serde(into = "Ed25519KeypairPickle")]
-pub(crate) struct Ed25519Keypair {
+pub struct Ed25519Keypair {
     secret_key: SecretKeys,
     public_key: Ed25519PublicKey,
     encoded_public_key: String,

--- a/src/types/ed25519.rs
+++ b/src/types/ed25519.rs
@@ -80,6 +80,12 @@ impl Ed25519Keypair {
     }
 }
 
+impl Default for Ed25519Keypair {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// An Ed25519 secret key, used to create digital signatures.
 #[derive(Deserialize, Serialize)]
 #[serde(transparent)]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,8 +17,10 @@ mod ed25519;
 
 pub use curve25519::Curve25519PublicKey;
 pub(crate) use curve25519::{Curve25519Keypair, Curve25519KeypairPickle, Curve25519SecretKey};
-pub(crate) use ed25519::{Ed25519Keypair, Ed25519KeypairPickle};
-pub use ed25519::{Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature, SignatureError};
+pub use ed25519::{
+    Ed25519Keypair, Ed25519KeypairPickle, Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature,
+    SignatureError,
+};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 


### PR DESCRIPTION
This is so that advanced systems can do non-standard stuff, without exposing those APIs by standard.