### PR TITLE
More typing for fallback keys and signatures

### DIFF
--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -39,7 +39,7 @@ use crate::{
         Ed25519Keypair, Ed25519KeypairPickle, Ed25519PublicKey, KeyId,
     },
     utilities::{pickle, unpickle, DecodeSecret},
-    DecodeError, PickleError,
+    DecodeError, Ed25519Signature, PickleError,
 };
 
 const PUBLIC_MAX_ONE_TIME_KEYS: usize = 50;
@@ -131,8 +131,8 @@ impl Account {
     }
 
     /// Sign the given message using our Ed25519 fingerprint key.
-    pub fn sign(&self, message: &str) -> String {
-        self.signing_key.sign(message.as_bytes()).to_base64()
+    pub fn sign(&self, message: &str) -> Ed25519Signature {
+        self.signing_key.sign(message.as_bytes())
     }
 
     /// Get the maximum number of one-time keys the client should keep on the

--- a/src/types/ed25519.rs
+++ b/src/types/ed25519.rs
@@ -249,6 +249,7 @@ impl Ed25519PublicKey {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Ed25519Signature(pub(crate) Signature);
 
 impl Ed25519Signature {


### PR DESCRIPTION
- fix(olm): Return the Curve25591PublicKey type for fallback keys
- fix(olm): Return the Ed25519Signature type when signing messages
