### PR TITLE
feat(types): Use base64 encoded public keys for Debug implementations

### DIFF
--- a/src/types/curve25519.rs
+++ b/src/types/curve25519.rs
@@ -89,7 +89,7 @@ impl Curve25519Keypair {
     }
 }
 
-#[derive(PartialEq, Eq, Hash, Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Curve25519PublicKey {
     pub(crate) inner: PublicKey,
@@ -153,6 +153,12 @@ impl Curve25519PublicKey {
     /// Serialize a Curve25519 public key to an unpadded base64 representation.
     pub fn to_base64(&self) -> String {
         base64_encode(self.inner.as_bytes())
+    }
+}
+
+impl std::fmt::Debug for Curve25519PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Curve25519PublicKey({})", self.to_base64())
     }
 }
 

--- a/src/types/ed25519.rs
+++ b/src/types/ed25519.rs
@@ -195,7 +195,7 @@ impl SecretKeys {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq)]
 #[serde(transparent)]
 pub struct Ed25519PublicKey(PublicKey);
 
@@ -246,6 +246,12 @@ impl Ed25519PublicKey {
         } else {
             Ok(self.0.verify(message, &signature.0)?)
         }
+    }
+}
+
+impl std::fmt::Debug for Ed25519PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Ed25519PublicKey({})", self.to_base64())
     }
 }
 


### PR DESCRIPTION
The default debug implementations needlessly show all the wrapping we are doing with the types and are quite verbose.

The base64 encoded variants of public keys can widely be used as a public key fingerprint.