### PR TITLE
Remove encoded public key variants of some methods

### DIFF
--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -267,18 +267,6 @@ impl Account {
             .collect()
     }
 
-    /// Get the currently unpublished one-time keys in base64-encoded form.
-    ///
-    /// The one-time keys should be published to a server and marked as
-    /// published using the `mark_keys_as_published()` method.
-    pub fn one_time_keys_encoded(&self) -> HashMap<String, String> {
-        self.one_time_keys
-            .unpublished_public_keys
-            .iter()
-            .map(|(key_id, key)| (key_id.to_base64(), key.to_base64()))
-            .collect()
-    }
-
     /// Generate a single new fallback key.
     ///
     /// The fallback key will be used by other users to establish a `Session` if
@@ -688,15 +676,13 @@ mod test {
 
         bob.generate_one_time_keys(1);
 
-        let one_time_key = bob
-            .one_time_keys_encoded()
-            .values()
-            .next()
-            .cloned()
-            .expect("Didn't find a valid one-time key");
+        let one_time_key =
+            bob.one_time_keys().values().next().cloned().expect("Didn't find a valid one-time key");
 
-        let alice_session =
-            alice.create_outbound_session(&bob.curve25519_key().to_base64(), &one_time_key)?;
+        let alice_session = alice.create_outbound_session(
+            &bob.curve25519_key().to_base64(),
+            &one_time_key.to_base64(),
+        )?;
 
         let text = "It's a secret to everybody";
         let message = alice_session.encrypt(text).into();
@@ -799,7 +785,7 @@ mod test {
         let mut olm_one_time_keys: Vec<_> =
             olm.parsed_one_time_keys().curve25519().values().map(|k| k.to_owned()).collect();
         let mut one_time_keys: Vec<_> =
-            unpickled.one_time_keys_encoded().values().map(|k| k.to_owned()).collect();
+            unpickled.one_time_keys().values().map(|k| k.to_base64()).collect();
 
         olm_one_time_keys.sort();
         one_time_keys.sort();

--- a/src/olm/mod.rs
+++ b/src/olm/mod.rs
@@ -60,7 +60,7 @@
 //!     let bob_otk = *bob.one_time_keys().values().next().unwrap();
 //!
 //!     let mut alice_session = alice
-//!         .create_outbound_session(*bob.curve25519_key(), bob_otk);
+//!         .create_outbound_session(bob.curve25519_key(), bob_otk);
 //!
 //!     bob.mark_keys_as_published();
 //!

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -563,7 +563,8 @@ mod test {
         bob.mark_keys_as_published();
 
         if let OlmMessage::PreKey(m) = olm_message.into() {
-            let session = bob.create_inbound_session_from(alice.curve25519_key_encoded(), m)?;
+            let session =
+                bob.create_inbound_session_from(&alice.curve25519_key().to_base64(), m)?;
 
             Ok((alice, bob, alice_session, session))
         } else {

--- a/src/types/curve25519.rs
+++ b/src/types/curve25519.rs
@@ -67,16 +67,14 @@ impl Default for Curve25519SecretKey {
 pub(crate) struct Curve25519Keypair {
     pub secret_key: Curve25519SecretKey,
     pub public_key: Curve25519PublicKey,
-    pub encoded_public_key: String,
 }
 
 impl Curve25519Keypair {
     pub fn new() -> Self {
         let secret_key = Curve25519SecretKey::new();
         let public_key = Curve25519PublicKey::from(&secret_key);
-        let encoded_public_key = base64_encode(public_key.as_bytes());
 
-        Self { secret_key, public_key, encoded_public_key }
+        Self { secret_key, public_key }
     }
 
     #[cfg(feature = "libolm-compat")]
@@ -84,19 +82,15 @@ impl Curve25519Keypair {
         let secret_key = Curve25519SecretKey::from_slice(key);
         let public_key = Curve25519PublicKey::from(&secret_key);
 
-        Curve25519Keypair { secret_key, public_key, encoded_public_key: public_key.to_base64() }
+        Curve25519Keypair { secret_key, public_key }
     }
 
     pub fn secret_key(&self) -> &Curve25519SecretKey {
         &self.secret_key
     }
 
-    pub fn public_key(&self) -> &Curve25519PublicKey {
-        &self.public_key
-    }
-
-    pub fn public_key_encoded(&self) -> &str {
-        &self.encoded_public_key
+    pub fn public_key(&self) -> Curve25519PublicKey {
+        self.public_key
     }
 }
 
@@ -209,9 +203,8 @@ impl From<Curve25519KeypairPickle> for Curve25519Keypair {
     fn from(pickle: Curve25519KeypairPickle) -> Self {
         let secret_key = pickle.0;
         let public_key: Curve25519PublicKey = (&secret_key).into();
-        let encoded_public_key = public_key.to_base64();
 
-        Self { secret_key, public_key, encoded_public_key }
+        Self { secret_key, public_key }
     }
 }
 


### PR DESCRIPTION
- refactor(types): Remove the encoded public key from the curve25519 types
- refactor(sas): Remove the encoded public key methods
- refactor(olm): Remove the encoded one-time keys method
