### PR TITLE
ci(docs): Enable the force_orphan option

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,3 +37,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc/
+          force_orphan: true


### PR DESCRIPTION
The force_orphan[[1]] option ensures that the branch that is used to publish the docs has only a single commit. This lowers the space that is used by the docs publishing branch.

[1]: https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-force-orphan-force_orphan