### PR TITLE
feat: Expose encrypting and decrypting bytes

### DIFF
--- a/src/megolm/group_session.rs
+++ b/src/megolm/group_session.rs
@@ -76,7 +76,7 @@ impl GroupSession {
     ///
     /// The resulting ciphertext is MAC-ed, then signed with the group session's
     /// Ed25519 key pair and finally base64-encoded.
-    pub fn encrypt(&mut self, plaintext: &str) -> MegolmMessage {
+    pub fn encrypt(&mut self, plaintext: impl AsRef<[u8]>) -> MegolmMessage {
         let cipher = Cipher::new_megolm(self.ratchet.as_bytes());
 
         let message = MegolmMessage::encrypt_private(

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -67,7 +67,7 @@ pub struct InboundGroupSession {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DecryptedMessage {
-    pub plaintext: String,
+    pub plaintext: Vec<u8>,
     pub message_index: u32,
 }
 
@@ -169,8 +169,7 @@ impl InboundGroupSession {
             let cipher = Cipher::new_megolm(ratchet.as_bytes());
 
             cipher.verify_mac(&message.to_mac_bytes(), &message.mac)?;
-            let plaintext =
-                String::from_utf8_lossy(&cipher.decrypt(&message.ciphertext)?).to_string();
+            let plaintext = cipher.decrypt(&message.ciphertext)?;
 
             Ok(DecryptedMessage { plaintext, message_index: message.message_index })
         } else {

--- a/src/megolm/mod.rs
+++ b/src/megolm/mod.rs
@@ -125,7 +125,7 @@ mod test {
 
         let decrypted = session.decrypt(&message)?;
 
-        assert_eq!(decrypted.plaintext, plaintext);
+        assert_eq!(decrypted.plaintext, plaintext.as_bytes());
         assert_eq!(decrypted.message_index, 0);
 
         let plaintext = "Another secret";
@@ -133,14 +133,14 @@ mod test {
 
         let decrypted = session.decrypt(&message)?;
 
-        assert_eq!(decrypted.plaintext, plaintext);
+        assert_eq!(decrypted.plaintext, plaintext.as_bytes());
         assert_eq!(decrypted.message_index, 1);
 
         let third_plaintext = "And another secret";
         let third_message = olm_session.encrypt(third_plaintext).as_str().try_into()?;
         let decrypted = session.decrypt(&third_message)?;
 
-        assert_eq!(decrypted.plaintext, third_plaintext);
+        assert_eq!(decrypted.plaintext, third_plaintext.as_bytes());
         assert_eq!(decrypted.message_index, 2);
 
         let plaintext = "Last secret";
@@ -152,12 +152,12 @@ mod test {
         let message = olm_session.encrypt(plaintext).as_str().try_into()?;
         let decrypted = session.decrypt(&message)?;
 
-        assert_eq!(decrypted.plaintext, plaintext);
+        assert_eq!(decrypted.plaintext, plaintext.as_bytes());
         assert_eq!(decrypted.message_index, 2002);
 
         let decrypted = session.decrypt(&third_message)?;
 
-        assert_eq!(decrypted.plaintext, third_plaintext);
+        assert_eq!(decrypted.plaintext, third_plaintext.as_bytes());
         assert_eq!(decrypted.message_index, 2);
 
         Ok(())
@@ -170,9 +170,9 @@ mod test {
 
         assert_eq!(session.session_id(), inbound.session_id());
 
-        let first_plaintext = "It's a secret to everybody";
+        let first_plaintext = "It's a secret to everybody".as_bytes();
         let first_message = session.encrypt(first_plaintext);
-        let second_plaintext = "It's dangerous to go alone. Take this!";
+        let second_plaintext = "It's dangerous to go alone. Take this!".as_bytes();
         let second_message = session.encrypt(second_plaintext);
 
         let decrypted = inbound.decrypt(&first_message)?;
@@ -277,7 +277,7 @@ mod test {
         assert_eq!(olm.session_id(), unpickled.session_id());
         assert_eq!(olm.session_message_index(), unpickled.message_index());
 
-        let plaintext = "It's a secret to everybody";
+        let plaintext = "It's a secret to everybody".as_bytes();
         let message = unpickled.encrypt(plaintext);
 
         let decrypted = inbound_session.decrypt(&message)?;

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -79,7 +79,7 @@ pub struct InboundCreationResult {
     /// The [`Session`] that was created from a pre-key message.
     pub session: Session,
     /// The plaintext of the pre-key message.
-    pub plaintext: String,
+    pub plaintext: Vec<u8>,
 }
 
 /// An Olm account manages all cryptographic keys used on a device.
@@ -235,7 +235,6 @@ impl Account {
 
             // Decrypt the message to check if the Session is actually valid.
             let plaintext = session.decrypt_decoded(&pre_key_message.message)?;
-            let plaintext = String::from_utf8_lossy(&plaintext).to_string();
 
             // We only drop the one-time key now, this is why we can't use a
             // one-time key type that takes `self`. If we didn't do this,
@@ -589,12 +588,12 @@ mod test {
             let reply = libolm_session.encrypt(reply_plain).into();
             let plaintext = alice_session.decrypt(&reply)?;
 
-            assert_eq!(&plaintext, reply_plain);
+            assert_eq!(plaintext, reply_plain.as_bytes());
 
             let another_reply = "Last one";
             let reply = libolm_session.encrypt(another_reply).into();
             let plaintext = alice_session.decrypt(&reply)?;
-            assert_eq!(&plaintext, another_reply);
+            assert_eq!(plaintext, another_reply.as_bytes());
 
             let last_text = "Nope, I'll have the last word";
             let olm_message = alice_session.encrypt(last_text).into();
@@ -638,30 +637,30 @@ mod test {
             assert_eq!(alice_session.session_id(), bob_session.session_id());
             assert_eq!(m.session_keys(), bob_session.session_keys());
 
-            assert_eq!(message, plaintext);
+            assert_eq!(message.as_bytes(), plaintext);
 
             let second_text = "Here's another secret to everybody";
             let olm_message = alice_session.encrypt(second_text);
 
             let plaintext = bob_session.decrypt(&olm_message)?;
-            assert_eq!(second_text, plaintext);
+            assert_eq!(second_text.as_bytes(), plaintext);
 
             let reply_plain = "Yes, take this, it's dangerous out there";
             let reply = bob_session.encrypt(reply_plain);
             let plaintext = alice_session.decrypt(&reply)?;
 
-            assert_eq!(&plaintext, reply_plain);
+            assert_eq!(plaintext, reply_plain.as_bytes());
 
             let another_reply = "Last one";
             let reply = bob_session.encrypt(another_reply);
             let plaintext = alice_session.decrypt(&reply)?;
-            assert_eq!(&plaintext, another_reply);
+            assert_eq!(plaintext, another_reply.as_bytes());
 
             let last_text = "Nope, I'll have the last word";
             let olm_message = alice_session.encrypt(last_text);
 
             let plaintext = bob_session.decrypt(&olm_message)?;
-            assert_eq!(last_text, plaintext);
+            assert_eq!(last_text.as_bytes(), plaintext);
         }
 
         Ok(())
@@ -696,7 +695,7 @@ mod test {
         assert_eq!(alice_session.session_id(), session.session_id());
         assert!(bob.one_time_keys.private_keys.is_empty());
 
-        assert_eq!(text, plaintext);
+        assert_eq!(text.as_bytes(), plaintext);
 
         Ok(())
     }
@@ -730,7 +729,7 @@ mod test {
             assert_eq!(alice_session.session_id(), session.session_id());
             assert!(bob.fallback_keys.fallback_key.is_some());
 
-            assert_eq!(text, plaintext);
+            assert_eq!(text.as_bytes(), plaintext);
         } else {
             bail!("Got invalid message type from olm_rs");
         };

--- a/src/olm/mod.rs
+++ b/src/olm/mod.rs
@@ -75,14 +75,14 @@
 //!
 //!         assert_eq!(alice_session.session_id(), bob_session.session_id());
 //!
-//!         assert_eq!(message, what_bob_received);
+//!         assert_eq!(message.as_bytes(), what_bob_received);
 //!
 //!         let bob_reply = "Yes. Take this, it's dangerous out there!";
 //!         let bob_encrypted_reply = bob_session.encrypt(bob_reply).into();
 //!
 //!         let what_alice_received = alice_session
 //!             .decrypt(&bob_encrypted_reply)?;
-//!         assert_eq!(&what_alice_received, bob_reply);
+//!         assert_eq!(what_alice_received, bob_reply.as_bytes());
 //!     }
 //!
 //!     Ok(())

--- a/src/olm/session/double_ratchet.rs
+++ b/src/olm/session/double_ratchet.rs
@@ -44,8 +44,8 @@ impl DoubleRatchet {
         }
     }
 
-    pub fn encrypt(&mut self, plaintext: &str) -> Message {
-        self.next_message_key().encrypt(plaintext.as_bytes())
+    pub fn encrypt(&mut self, plaintext: &[u8]) -> Message {
+        self.next_message_key().encrypt(plaintext)
     }
 
     pub fn active(shared_secret: Shared3DHSecret) -> Self {


### PR DESCRIPTION
This is a proposal to allow using bytes directly without extra
conversion steps.

Use case: I am using protobuf encoded messages and encrypt them with
Olm. Now if I want to decrypt an Olm message vodozemac will decrypt the
message convert bytes into string and return it to me. Me, in turn, need
to convert string back into bytes and then decode my protobuf message.
The same thing happens when encoding a message.

What do you think? Current implementation breaks `InboundCreationResult` type for implementation simplicity.