### PR TITLE
Upgrade x25519-dalek to 2.0.0-pre.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ rand = "0.7.3"
 subtle = "2.4.1"
 sha2 = "0.10.2"
 thiserror = "1.0.30"
-x25519-dalek = { version = "1.2.0", features = ["serde", "reusable_secrets"] }
+x25519-dalek = { version = "2.0.0-pre.1", features = ["serde", "reusable_secrets"] }
 zeroize = "1.3.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"


### PR DESCRIPTION
The changes from the currently-used version are [trivial](https://github.com/dalek-cryptography/x25519-dalek/compare/1.2.0...2.0.0-pre.1), but they're required to upgrade to the latest version of zeroize in dependent crates.