### PR TITLE
refactor!(megolm): Change from_bytes to take a slice instead of a vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,4 +58,4 @@ olm-rs = "2.2.0"
 proptest = "1.0.0"
 
 [patch.crates-io]
-olm-rs = { git = "https://gitlab.gnome.org/poljar/olm-rs/" }
+olm-rs = { git = "https://github.com/poljar/olm-rs" }

--- a/src/megolm/message.rs
+++ b/src/megolm/message.rs
@@ -71,7 +71,7 @@ impl MegolmMessage {
     ///
     /// The expected format of the byte array is described in the
     /// [`MegolmMessage::to_bytes()`] method.
-    pub fn from_bytes(message: Vec<u8>) -> Result<Self, DecodeError> {
+    pub fn from_bytes(message: &[u8]) -> Result<Self, DecodeError> {
         Self::try_from(message)
     }
 


### PR DESCRIPTION
All our other from_bytes methods take slices, so this makes it consistent with the rest of the codebase.
