### PR TITLE
chore: Replace unmaintained actions-rs/* actions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,13 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: nightly
         components: rustfmt
-        profile: minimal
-        override: true
 
     - name: Cargo fmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      run: cargo fmt --all -- --check
 
   typos:
     name: Spell Check with Typos
@@ -52,20 +47,15 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: nightly
         components: clippy
-        profile: minimal
-        override: true
 
     - uses: Swatinem/rust-cache@v2
 
     - name: Clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --all-targets -- -D warnings
+      run: cargo clippy --all-targets -- -D warnings
 
   test:
     name: ${{ matrix.target.name }}
@@ -86,16 +76,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ format('{0}-{1}', matrix.channel, matrix.target.toolchain) }}
-          profile: minimal
-          override: true
 
       - uses: Swatinem/rust-cache@v2
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+        run: cargo test --all-features

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,26 +22,18 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-        profile: minimal
-        override: true
 
     - name: Load cache
       uses: Swatinem/rust-cache@v2
 
     - name: Install tarpaulin
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: cargo-tarpaulin
+      run: cargo install cargo-tarpaulin
 
     - name: Run tarpaulin
-      uses: actions-rs/cargo@v1
-      with:
-        command: tarpaulin
-        args: --out Xml
+      run: cargo tarpaulin --out Xml
 
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,21 +15,16 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
 
       - uses: Swatinem/rust-cache@v2
 
       - name: Build docs
-        uses: actions-rs/cargo@v1
+        run: cargo doc --no-deps -Zrustdoc-map
         env:
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options --cfg docsrs"
-        with:
-          command: doc
-          args: --no-deps -Zrustdoc-map
 
       - name: Deploy docs
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/matrix-org/vodozemac/actions/runs/4881349941:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of those warnings the occurrences of `actions-rs/toolchain` are replaced by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain), and the occurrences of `actions-rs/cargo` are replaced by direct invocations of `cargo`.