### PR TITLE
Revert "Expose the build-time git commit hash and description as static vars"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,9 +52,6 @@ thiserror = "1.0.30"
 x25519-dalek = { version = "1.2.0", features = ["serde", "reusable_secrets"] }
 zeroize = "1.3.0"
 
-[build-dependencies]
-vergen = { version = "8.1.3", features = ["build", "git", "gitcl"] }
-
 [dev-dependencies]
 anyhow = "1.0.57"
 assert_matches = "1.5.0"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,0 @@
-use std::error::Error;
-
-use vergen::EmitBuilder;
-
-fn main() -> Result<(), Box<dyn Error>> {
-    EmitBuilder::builder().git_describe(true, false, None).git_sha(true).emit()?;
-    Ok(())
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,11 +302,6 @@ pub enum DecodeError {
 
 /// The version of vodozemac that is being used.
 pub static VERSION: &str = env!("CARGO_PKG_VERSION");
-/// The git commit hash of the vodozemac source tree at build time.
-pub static GIT_SHA: &str = env!("VERGEN_GIT_SHA");
-/// The output of the git describe command of the vodozemac source tree at build
-/// time.
-pub static GIT_DESCRIPTION: &str = env!("VERGEN_GIT_DESCRIBE");
 
 #[cfg(test)]
 fn corpus_data_path(fuzz_target: &str) -> std::path::PathBuf {


### PR DESCRIPTION
That was a brain fart, we don't upload the git tree to crates.io. We can't reliably know the git commit at build time.

Reverts matrix-org/vodozemac#106