### PR TITLE
feat: Expose the base64 decoding and encoding methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,7 @@ pub use types::{
     Curve25519PublicKey, Curve25519SecretKey, Ed25519Keypair, Ed25519PublicKey, Ed25519SecretKey,
     Ed25519Signature, KeyError, KeyId, SharedSecret, SignatureError,
 };
+pub use utilities::{base64_decode, base64_encode};
 
 /// Error type describing the various ways Vodozemac pickles can fail to be
 /// decoded.

--- a/src/megolm/message.rs
+++ b/src/megolm/message.rs
@@ -33,7 +33,7 @@ const VERSION: u8 = 4;
 /// An encrypted Megolm message.
 ///
 /// Contains metadata that is required to find the correct ratchet state of a
-/// [`InboundGroupSession`] necessary to decryp the message.
+/// [`InboundGroupSession`] necessary to decrypt the message.
 ///
 /// [`InboundGroupSession`]: crate::megolm::InboundGroupSession
 #[derive(Clone, PartialEq, Eq)]


### PR DESCRIPTION
Consumers of this crate might need to encode or decode base64 as well. To have a consistent decoding experience they would need to replicate the exact config we're using.

Let's just expose the methods so consumers don't need to think about the exact base64 config to use.