### PR TITLE
Added ExportedSessionKey conversion trait for SessionKey

### DIFF
--- a/src/megolm/session_keys.rs
+++ b/src/megolm/session_keys.rs
@@ -314,6 +314,13 @@ impl TryFrom<&str> for SessionKey {
     }
 }
 
+impl From<&ExportedSessionKey> for SessionKey {
+    fn from(value: &ExportedSessionKey) -> Self {
+        let ratchet = Ratchet::from_bytes(value.ratchet.clone(), value.ratchet_index);
+        SessionKey::new(&ratchet, value.signing_key)
+    }
+}
+
 impl Serialize for SessionKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
Added helper conversion trait for MSC3061 implementation. See following PR for more details: https://github.com/matrix-org/matrix-rust-sdk/pull/2650

Signed-off-by: Michael Hollister <michael@futo.org>
