### PR TITLE
Detect 'sign'-related typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,2 +1,8 @@
+# all of these are valid words, but should never appear in this repo
+[default.extend-words]
+sing = "sign"
+singed = "signed"
+singing = "signing"
+
 [files]
 extend-exclude = ["vendor/*"]


### PR DESCRIPTION
Looks like there are currently no such typos here, but it has happened a lot in the SDK so why not check for it here too.