### PR TITLE
Add the RatchetKey to the Debug output of the ReceiverChain

### DIFF
--- a/src/olm/session/receiver_chain.rs
+++ b/src/olm/session/receiver_chain.rs
@@ -97,9 +97,10 @@ pub(super) struct ReceiverChain {
 
 impl Debug for ReceiverChain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self { ratchet_key: _, hkdf_ratchet, skipped_message_keys } = self;
+        let Self { ratchet_key, hkdf_ratchet, skipped_message_keys } = self;
 
         f.debug_struct("ReceiverChain")
+            .field("ratchet_key", &ratchet_key)
             .field("chain_index", &hkdf_ratchet.chain_index())
             .field("skipped_message_keys", &skipped_message_keys.inner)
             .finish_non_exhaustive()


### PR DESCRIPTION
The ratchet key is a crucial piece of information when trying to debug a decryption failure of a Olm Session.

The ratchet key and chain index, which are found inside a Olm message, form a pair which uniquely identifies the individual message key that should be used to decrypt the message.

To inspect why a decryption failure occurs it's useful to have the ratchet key and chain index pair, this allows us to double check if the correct chain is part of the Session.
