### PR TITLE
test(olm): Add more tests

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,6 @@
+exclude_re = [
+  # Coverage of debug functions is not relevant
+  "impl Debug",
+  # Replacing + with * makes no logical difference here
+  "src/olm/messages/message\\.rs.*replace \\+ with \\* in <impl TryFrom for Message>::try_from",
+]


### PR DESCRIPTION
Relates to: #78

Fixes the following:

```
MISSED   src/olm/messages/message.rs:63:9: replace Message::version -> u8 with 0 in 0.8s build + 2.8s test
MISSED   src/olm/messages/message.rs:58:9: replace Message::ciphertext -> &[u8] with Vec::leak(vec![1]) in 0.8s build + 3.2s test
MISSED   src/olm/messages/message.rs:58:9: replace Message::ciphertext -> &[u8] with Vec::leak(Vec::new()) in 0.8s build + 3.0s test
MISSED   src/olm/messages/message.rs:63:9: replace Message::version -> u8 with 1 in 0.8s build + 2.8s test
MISSED   src/olm/messages/message.rs:58:9: replace Message::ciphertext -> &[u8] with Vec::leak(vec![0]) in 0.8s build + 2.8s test
MISSED   src/olm/messages/message.rs:53:9: replace Message::chain_index -> u64 with 1 in 0.8s build + 2.8s test
MISSED   src/olm/messages/message.rs:53:9: replace Message::chain_index -> u64 with 0 in 0.8s build + 2.9s test
MISSED   src/olm/messages/message.rs:217:37: replace + with - in <impl TryFrom for Message>::try_from in 0.8s build + 2.9s test
```

Does not fix:

```
MISSED   src/olm/messages/message.rs:247:9: replace <impl Debug for Message>::fmt -> std::fmt::Result with Ok(Default::default()) in 0.8s build + 3.6s test
MISSED   src/olm/messages/message.rs:217:37: replace + with * in <impl TryFrom for Message>::try_from in 0.8s build + 2.9s test
```