### PR TITLE
test(olm): Add mutation tests for message_key

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,6 +1,9 @@
+additional_cargo_args = ["--all-features"]
 exclude_re = [
   # Coverage of debug functions is not relevant
   "impl Debug",
   # Replacing + with * makes no logical difference here
   "src/olm/messages/message\\.rs.*replace \\+ with \\* in <impl TryFrom for Message>::try_from",
+  # Drop implementations perform zeroisation which cannot be tested in Rust
+  "impl Drop",
 ]

--- a/src/olm/session/message_key.rs
+++ b/src/olm/session/message_key.rs
@@ -137,3 +137,21 @@ impl RemoteMessageKey {
         }
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "low-level-api")]
+mod test {
+    use super::MessageKey;
+    use crate::olm::RatchetPublicKey;
+
+    #[test]
+    fn low_level_getters() {
+        let key = b"11111111111111111111111111111111";
+        let ratchet_key = RatchetPublicKey::from(*b"22222222222222222222222222222222");
+        let index: u64 = 3;
+        let message_key = MessageKey::new(Box::new(*key), ratchet_key, index);
+        assert_eq!(message_key.key(), key);
+        assert_eq!(message_key.ratchet_key(), ratchet_key);
+        assert_eq!(message_key.index(), index);
+    }
+}


### PR DESCRIPTION
Testing the getters is a bit dull but since they're not actually used anywhere else in the library, this seems like the only way to catch their mutants.

I also excluded all `Drop` mutants because it doesn't look like the zeroisation can be tested in Rust. I tried using raw pointers into the struct fields in a test but the memory didn't end up reliably zeroed – I think because `drop` moves the value which can perform a memory copy.

Relates to: #78