### PR TITLE
test(olm): Add mutation tests for pre_key

### DIFF
--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -780,6 +780,7 @@ mod test {
 
         if let OlmMessage::PreKey(m) = olm_message {
             assert_eq!(m.session_keys(), alice_session.session_keys());
+            assert_eq!(m.session_id(), alice_session.session_id());
 
             let InboundCreationResult { session: mut bob_session, plaintext } =
                 bob.create_inbound_session(alice.curve25519_key(), &m)?;


### PR DESCRIPTION
This fixes:

```
MISSED   src/olm/messages/pre_key.rs:81:9: replace PreKeyMessage::session_id -> String with String::new() in 0.9s build + 3.2s test
MISSED   src/olm/messages/pre_key.rs:81:9: replace PreKeyMessage::session_id -> String with "xyzzy".into() in 0.8s build + 2.8s test
```

Relates to: #78