### PR TITLE
Log ratchet keys in `olm::Session::debug`

### DIFF
--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -158,7 +158,7 @@ impl Debug for Session {
 
         f.debug_struct("Session")
             .field("session_id", &self.session_id())
-            .field("sending_chain_index", &sending_ratchet.chain_index())
+            .field("sending_ratchet", &sending_ratchet)
             .field("receiving_chains", &receiving_chains.inner)
             .field("config", config)
             .finish_non_exhaustive()

--- a/src/olm/session/receiver_chain.rs
+++ b/src/olm/session/receiver_chain.rs
@@ -88,10 +88,28 @@ impl FoundMessageKey<'_> {
     }
 }
 
+/// The receiver side data on a single chain in the double ratchet.
+///
+/// Contains the data needed to decrypt a message sent to a given chain.
 #[derive(Serialize, Deserialize, Clone)]
 pub(super) struct ReceiverChain {
+    /// The sender's ratchet key `T`<sub>`i`</sub> for this chain.
+    ///
+    /// We store this mostly so that we can identify which chain to use to
+    /// decrypt a given message.
     ratchet_key: RemoteRatchetKey,
+
+    /// The chain key `C`<sub>`i`,`j`</sub>.
+    ///
+    /// As we receive more messages on the chain, this is ratcheted forward,
+    /// producing a new chain key `C`<sub>`i`,`j+1`</sub>, from which we can
+    /// derive a new message key `M`<sub>`i`,`j+1`</sub>.
     hkdf_ratchet: RemoteChainKey,
+
+    /// A stash of message keys which have not yet been used to decrypt a
+    /// message.
+    ///
+    /// This allows us to handle out-of-order messages.
     skipped_message_keys: MessageKeyStore,
 }
 

--- a/src/olm/session/root_key.rs
+++ b/src/olm/session/root_key.rs
@@ -24,6 +24,16 @@ use super::{
 
 const ADVANCEMENT_SEED: &[u8; 11] = b"OLM_RATCHET";
 
+/// A root key for one of our own sender chains.
+///
+/// A new root key `R`<sub>`i`</sub> is calculated each time the conversation
+/// changes direction, based on the previous root key `R`<sub>`i-1`</sub> and
+/// the previous and new [ratchet keys](RatchetKey) `T`<sub>`i-1`</sub>,
+/// `T`<sub>`i`</sub>. It is used only to calculate the *next* root key
+/// `R`<sub>`i+1`</sub> and [chain key](ChainKey) `C`<sub>`i+1`</sub>.
+///
+/// This struct holds the root key corresponding to chains where we are the
+/// sender. See also [`RemoteRootKey`].
 #[derive(Serialize, Deserialize, Clone, Zeroize)]
 #[serde(transparent)]
 #[zeroize(drop)]
@@ -31,6 +41,10 @@ pub(crate) struct RootKey {
     pub key: Box<[u8; 32]>,
 }
 
+/// A root key for one of the other side's sender chains.
+///
+/// See [`RootKey`] for information on root keys. This struct holds the root key
+/// corresponding to chains where the other side is the sender.
 #[derive(Serialize, Deserialize, Clone, Zeroize)]
 #[zeroize(drop)]
 pub(crate) struct RemoteRootKey {


### PR DESCRIPTION
Include the latest public ratchet keys in the debug output.

Fixes #125. Review commit-by-commit.

Question: does any of this need to be behind a feature flag? It's all public data so it feels like it's not a problem to retain or log it, but in theory I suppose there's a reduction in security due to keeping the parent ratchet key around.