### PR TITLE
Track the number of ratchet advances in the Olm Session, and include it in the debug output.

### DIFF
--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -534,7 +534,10 @@ mod test {
 
     const PICKLE_KEY: [u8; 32] = [0u8; 32];
 
-    fn sessions() -> Result<(Account, OlmAccount, Session, OlmSession)> {
+    /// Create a pair of accounts, one using vodozemac and one libolm.
+    ///
+    /// Then, create a pair of sessions between the two.
+    pub fn session_and_libolm_pair() -> Result<(Account, OlmAccount, Session, OlmSession)> {
         let alice = Account::new();
         let bob = OlmAccount::new();
         bob.generate_one_time_keys(1);
@@ -570,7 +573,7 @@ mod test {
 
     #[test]
     fn out_of_order_decryption() {
-        let (_, _, mut alice_session, bob_session) = sessions().unwrap();
+        let (_, _, mut alice_session, bob_session) = session_and_libolm_pair().unwrap();
 
         let message_1 = bob_session.encrypt("Message 1").into();
         let message_2 = bob_session.encrypt("Message 2").into();
@@ -592,7 +595,7 @@ mod test {
 
     #[test]
     fn more_out_of_order_decryption() {
-        let (_, _, mut alice_session, bob_session) = sessions().unwrap();
+        let (_, _, mut alice_session, bob_session) = session_and_libolm_pair().unwrap();
 
         let message_1 = bob_session.encrypt("Message 1").into();
         let message_2 = bob_session.encrypt("Message 2").into();
@@ -630,7 +633,7 @@ mod test {
 
     #[test]
     fn max_keys_out_of_order_decryption() {
-        let (_, _, mut alice_session, bob_session) = sessions().unwrap();
+        let (_, _, mut alice_session, bob_session) = session_and_libolm_pair().unwrap();
 
         let mut messages: Vec<messages::OlmMessage> = Vec::new();
         for i in 0..(MAX_MESSAGE_KEYS + 2) {
@@ -664,7 +667,7 @@ mod test {
 
     #[test]
     fn max_gap_out_of_order_decryption() {
-        let (_, _, mut alice_session, bob_session) = sessions().unwrap();
+        let (_, _, mut alice_session, bob_session) = session_and_libolm_pair().unwrap();
 
         for i in 0..(MAX_MESSAGE_GAP + 1) {
             bob_session.encrypt(format!("Message {}", i).as_str());
@@ -680,7 +683,7 @@ mod test {
     #[test]
     #[cfg(feature = "libolm-compat")]
     fn libolm_unpickling() {
-        let (_, _, mut session, olm) = sessions().unwrap();
+        let (_, _, mut session, olm) = session_and_libolm_pair().unwrap();
 
         let plaintext = "It's a secret to everybody";
         let old_message = session.encrypt(plaintext);
@@ -717,7 +720,7 @@ mod test {
 
     #[test]
     fn session_pickling_roundtrip_is_identity() {
-        let (_, _, session, _) = sessions().unwrap();
+        let (_, _, session, _) = session_and_libolm_pair().unwrap();
 
         let pickle = session.pickle().encrypt(&PICKLE_KEY);
 


### PR DESCRIPTION
In order to help understand Olm decryption errors, let's keep track of the number of DH ratchet clicks, and log them as part of the debug output.