### PR TITLE
test(types): Add mutation tests for curve25519

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,7 +1,8 @@
 additional_cargo_args = ["--all-features"]
 exclude_re = [
-  # Coverage of debug functions is not relevant
+  # Coverage of debug & display functions is not relevant
   "impl Debug",
+  "impl Display",
   # Replacing + with * makes no logical difference here
   "src/olm/messages/message\\.rs.*replace \\+ with \\* in <impl TryFrom for Message>::try_from",
   # Drop implementations perform zeroisation which cannot be tested in Rust

--- a/src/types/curve25519.rs
+++ b/src/types/curve25519.rs
@@ -246,7 +246,7 @@ impl From<Curve25519Keypair> for Curve25519KeypairPickle {
 #[cfg(test)]
 mod tests {
     use super::Curve25519PublicKey;
-    use crate::{utilities::DecodeError, KeyError};
+    use crate::{utilities::DecodeError, Curve25519SecretKey, KeyError};
 
     #[test]
     fn decoding_invalid_base64_fails() {
@@ -282,5 +282,21 @@ mod tests {
     fn decoding_of_correct_num_of_bytes_succeeds() {
         let base64_payload = "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA";
         assert!(matches!(Curve25519PublicKey::from_base64(base64_payload), Ok(..)));
+    }
+
+    #[test]
+    fn byte_decoding_roundtrip_succeeds_for_public_key() {
+        let bytes = *b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let key = Curve25519PublicKey::from_bytes(bytes);
+        assert_eq!(key.to_bytes(), bytes);
+        assert_eq!(key.as_bytes(), &bytes);
+        assert_eq!(key.to_vec(), bytes.to_vec());
+    }
+
+    #[test]
+    fn byte_decoding_roundtrip_succeeds_for_secret_key() {
+        let bytes = *b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let key = Curve25519SecretKey::from_slice(&bytes);
+        assert_eq!(*(key.to_bytes()), bytes);
     }
 }


### PR DESCRIPTION
This fixes:

```
MISSED   src/types/curve25519.rs:58:9: replace Curve25519SecretKey::to_bytes -> Box<[u8; 32]> with Box::new([0; 32]) in 0.9s build + 3.0s test
MISSED   src/types/curve25519.rs:192:9: replace <impl Display for Curve25519PublicKey>::fmt -> std::fmt::Result with Ok(Default::default()) in 0.8s build + 3.1s test
MISSED   src/types/curve25519.rs:143:9: replace Curve25519PublicKey::to_vec -> Vec<u8> with vec![0] in 0.8s build + 3.1s test
MISSED   src/types/curve25519.rs:58:9: replace Curve25519SecretKey::to_bytes -> Box<[u8; 32]> with Box::new([1; 32]) in 0.9s build + 3.3s test
MISSED   src/types/curve25519.rs:143:9: replace Curve25519PublicKey::to_vec -> Vec<u8> with vec![1] in 0.8s build + 2.8s test
MISSED   src/types/curve25519.rs:143:9: replace Curve25519PublicKey::to_vec -> Vec<u8> with vec![] in 0.8s build + 2.8s test
```

Relates to: #78