### PR TITLE
test(olm): Add mutation tests for account

### DIFF
--- a/src/olm/account/fallback_keys.rs
+++ b/src/olm/account/fallback_keys.rs
@@ -133,4 +133,17 @@ mod test {
 
         assert_eq!(secret_bytes, fetched_key.to_bytes());
     }
+
+    #[test]
+    fn fallback_key_publishing() {
+        let mut fallback_keys = FallbackKeys::new();
+        assert_eq!(fallback_keys.key_id, 0);
+
+        fallback_keys.generate_fallback_key();
+        assert_eq!(fallback_keys.key_id, 1);
+        assert!(fallback_keys.unpublished_fallback_key().is_some());
+
+        fallback_keys.mark_as_published();
+        assert!(fallback_keys.unpublished_fallback_key().is_none());
+    }
 }

--- a/src/olm/account/one_time_keys.rs
+++ b/src/olm/account/one_time_keys.rs
@@ -192,14 +192,21 @@ mod test {
         assert!(store.private_keys.is_empty());
 
         store.generate(OneTimeKeys::MAX_ONE_TIME_KEYS);
-        assert_eq!(store.private_keys.len(), OneTimeKeys::MAX_ONE_TIME_KEYS);
         assert_eq!(store.unpublished_public_keys.len(), OneTimeKeys::MAX_ONE_TIME_KEYS);
+        assert_eq!(store.private_keys.len(), OneTimeKeys::MAX_ONE_TIME_KEYS);
         assert_eq!(store.key_ids_by_key.len(), OneTimeKeys::MAX_ONE_TIME_KEYS);
+
+        store
+            .private_keys
+            .keys()
+            .for_each(|key_id| assert!(!store.is_secret_key_published(key_id)));
 
         store.mark_as_published();
         assert!(store.unpublished_public_keys.is_empty());
         assert_eq!(store.private_keys.len(), OneTimeKeys::MAX_ONE_TIME_KEYS);
         assert_eq!(store.key_ids_by_key.len(), OneTimeKeys::MAX_ONE_TIME_KEYS);
+
+        store.private_keys.keys().for_each(|key_id| assert!(store.is_secret_key_published(key_id)));
 
         let oldest_key_id =
             store.private_keys.keys().next().copied().expect("Couldn't get the first key ID");
@@ -209,6 +216,17 @@ mod test {
         assert_eq!(store.unpublished_public_keys.len(), 10);
         assert_eq!(store.private_keys.len(), OneTimeKeys::MAX_ONE_TIME_KEYS);
         assert_eq!(store.key_ids_by_key.len(), OneTimeKeys::MAX_ONE_TIME_KEYS);
+
+        store
+            .private_keys
+            .keys()
+            .take(OneTimeKeys::MAX_ONE_TIME_KEYS - 10)
+            .for_each(|key_id| assert!(store.is_secret_key_published(key_id)));
+        store
+            .private_keys
+            .keys()
+            .skip(OneTimeKeys::MAX_ONE_TIME_KEYS - 10)
+            .for_each(|key_id| assert!(!store.is_secret_key_published(key_id)));
 
         let oldest_key_id =
             store.private_keys.keys().next().copied().expect("Couldn't get the first key ID");


### PR DESCRIPTION
This fixes:

```
MISSED   src/olm/account/one_time_keys.rs:126:9: replace OneTimeKeys::is_secret_key_published -> bool with false in 0.9s build + 3.5s test
MISSED   src/olm/account/one_time_keys.rs:126:9: replace OneTimeKeys::is_secret_key_published -> bool with true in 0.9s build + 3.4s test
```

```
MISSED   src/olm/account/fallback_keys.rs:53:9: replace FallbackKey::published -> bool with false in 0.8s build + 3.0s test
MISSED   src/olm/account/fallback_keys.rs:70:9: replace FallbackKeys::mark_as_published with () in 0.8s build + 3.3s test
MISSED   src/olm/account/fallback_keys.rs:77:21: replace += with *= in FallbackKeys::generate_fallback_key in 0.8s build + 3.1s test
MISSED   src/olm/account/fallback_keys.rs:49:9: replace FallbackKey::mark_as_published with () in 0.8s build + 3.1s test
```

```
MISSED   src/olm/account/mod.rs:289:9: replace Account::stored_one_time_key_count -> usize with 1 in 1.0s build + 3.0s test
MISSED   src/olm/account/mod.rs:334:9: replace Account::forget_fallback_key -> bool with true in 0.8s build + 3.3s test
MISSED   src/olm/account/mod.rs:334:9: replace Account::forget_fallback_key -> bool with false in 1.0s build + 3.0s test
MISSED   src/olm/account/mod.rs:289:9: replace Account::stored_one_time_key_count -> usize with 0 in 0.8s build + 2.9s test
MISSED   src/olm/account/mod.rs:339:9: replace Account::mark_keys_as_published with () in 1.0s build + 3.9s test
MISSED   src/olm/account/mod.rs:551:25: replace += with *= in libolm::<impl Encode for FallbackKeysArray>::encode in 1.1s build + 3.2s test
MISSED   src/olm/account/mod.rs:552:25: replace += with -= in libolm::<impl Encode for FallbackKeysArray>::encode in 0.9s build + 3.1s test
MISSED   src/olm/account/mod.rs:201:9: replace Account::remove_one_time_key -> Option<Curve25519SecretKey> with None in 1.0s build + 3.1s test
MISSED   src/olm/account/mod.rs:152:9: replace Account::max_number_of_one_time_keys -> usize with 0 in 0.8s build + 2.9s test
MISSED   src/olm/account/mod.rs:201:9: replace Account::remove_one_time_key -> Option<Curve25519SecretKey> with Some(Default::default()) in 0.9s build + 2.9s test
MISSED   src/olm/account/mod.rs:152:9: replace Account::max_number_of_one_time_keys -> usize with 1 in 0.8s build + 3.0s test
MISSED   src/olm/account/mod.rs:545:25: replace += with *= in libolm::<impl Encode for FallbackKeysArray>::encode in 1.0s build + 3.1s test
MISSED   src/olm/account/mod.rs:552:25: replace += with *= in libolm::<impl Encode for FallbackKeysArray>::encode in 0.9s build + 3.0s test
MISSED   src/olm/account/mod.rs:419:9: replace Account::from_decrypted_libolm_pickle -> Result<Self, crate::LibolmPickleError> with Ok(Default::default()) in 1.1s build + 2.6s test
MISSED   src/olm/account/mod.rs:551:25: replace += with -= in libolm::<impl Encode for FallbackKeysArray>::encode in 1.0s build + 3.2s test
```

Relates to: #78