### PR TITLE
test(sas): Add mutation tests

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -5,6 +5,8 @@ exclude_re = [
   "impl Display",
   # Replacing + with * makes no logical difference here
   "src/olm/messages/message\\.rs.*replace \\+ with \\* in <impl TryFrom for Message>::try_from",
+  # Due to the bit shifting | and ^ are equivalent here
+  "replace \\| with \\^ in SasBytes::bytes_to_decimal",
   # Drop implementations perform zeroisation which cannot be tested in Rust
   "impl Drop",
 ]


### PR DESCRIPTION
This fixes the following:

```
MISSED   src/sas.rs:152:9: replace SasBytes::emoji_indices -> [u8; 7] with [0; 7] in 0.8s build + 3.4s test
MISSED   src/sas.rs:152:9: replace SasBytes::emoji_indices -> [u8; 7] with [1; 7] in 0.9s build + 3.4s test
MISSED   src/sas.rs:160:9: replace SasBytes::decimals -> (u16, u16, u16) with (0, 0, 0) in 0.8s build + 3.1s test
MISSED   src/sas.rs:160:9: replace SasBytes::decimals -> (u16, u16, u16) with (0, 0, 1) in 0.8s build + 3.7s test
MISSED   src/sas.rs:160:9: replace SasBytes::decimals -> (u16, u16, u16) with (0, 1, 0) in 0.8s build + 3.0s test
MISSED   src/sas.rs:160:9: replace SasBytes::decimals -> (u16, u16, u16) with (0, 1, 1) in 0.8s build + 3.0s test
MISSED   src/sas.rs:160:9: replace SasBytes::decimals -> (u16, u16, u16) with (1, 0, 0) in 0.8s build + 3.7s test
MISSED   src/sas.rs:160:9: replace SasBytes::decimals -> (u16, u16, u16) with (1, 0, 1) in 0.8s build + 3.0s test
MISSED   src/sas.rs:160:9: replace SasBytes::decimals -> (u16, u16, u16) with (1, 1, 0) in 0.8s build + 3.0s test
MISSED   src/sas.rs:160:9: replace SasBytes::decimals -> (u16, u16, u16) with (1, 1, 1) in 0.8s build + 3.7s test
MISSED   src/sas.rs:166:9: replace SasBytes::as_bytes -> &[u8; 6] with &[0; 6] in 0.8s build + 2.9s test
MISSED   src/sas.rs:166:9: replace SasBytes::as_bytes -> &[u8; 6] with &[1; 6] in 0.8s build + 2.9s test
MISSED   src/sas.rs:204:35: replace | with ^ in SasBytes::bytes_to_decimal in 0.9s build + 3.0s test
MISSED   src/sas.rs:205:45: replace | with ^ in SasBytes::bytes_to_decimal in 0.8s build + 2.9s test
MISSED   src/sas.rs:205:61: replace | with ^ in SasBytes::bytes_to_decimal in 0.8s build + 2.9s test
MISSED   src/sas.rs:206:44: replace | with ^ in SasBytes::bytes_to_decimal in 0.8s build + 3.7s test
MISSED   src/sas.rs:384:9: replace EstablishedSas::verify_mac -> Result<(), SasError> with Ok(()) in 0.9s build + 3.8s test
```

While at it, I also removed the `Result` return values in the same file as recommended on one of my earlier PRs.

Relates to: #78