### PR TITLE
test(megolm): Add mutation tests

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -7,11 +7,18 @@ exclude_re = [
   "src/olm/messages/message\\.rs.*replace \\+ with \\* in <impl TryFrom for Message>::try_from",
   # Due to the bit shifting | and ^ are equivalent here
   "replace \\| with \\^ in SasBytes::bytes_to_decimal",
-  # Drop implementations perform zeroisation which cannot be tested in Rust
-  "impl Drop",
+  # Drop & Zeroize implementations perform zeroisation which cannot be tested in Rust
+  "impl (Drop|Zeroize)",
   # These cause olm/account tests to hang
   "RemoteChainKey::chain_index",
   "RemoteChainKey::advance",
   # The constant value can't really be tested
   "src/olm/account/one_time_keys\\.rs.*replace \\* with \\+$",
+  # Not testable because the latest ratchet is cloned from the initial one when it's past the requested index
+  "replace < with == in InboundGroupSession::find_ratchet",
+  # Causes an infinite loop
+  "replace -= with \\+= in Ratchet::advance_to",
+  # Causes an infinite loop
+  "replace -= with /= in Ratchet::advance_to",
+
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       run: cargo clippy --all-targets -- -D warnings
 
   test:
-    name: ${{ matrix.target.name }}
+    name: ${{ matrix.target.name }} ${{ matrix.channel }}
     needs: [clippy]
 
     runs-on: ${{ matrix.target.os }}
@@ -66,8 +66,8 @@ jobs:
       matrix:
         target: [
           { "os": "ubuntu-latest",  "toolchain": "x86_64-unknown-linux-gnu", "name": "Linux GNU" },
-          { "os": "macos-13",       "toolchain": "x86_64-apple-darwin ",     "name": "macOS (x86)" },
-          { "os": "macos-latest",   "toolchain": "aarch64-apple-darwin",     "name": "macOS (ARM)" },
+          { "os": "macos-13",       "toolchain": "x86_64-apple-darwin ",     "name": "macOS x86" },
+          { "os": "macos-latest",   "toolchain": "aarch64-apple-darwin",     "name": "macOS arm" },
           { "os": "windows-latest", "toolchain": "x86_64-pc-windows-msvc",   "name": "Windows MSVC" },
         ]
         channel: [stable, beta, nightly]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,8 @@ jobs:
       matrix:
         target: [
           { "os": "ubuntu-latest",  "toolchain": "x86_64-unknown-linux-gnu", "name": "Linux GNU" },
-          { "os": "macOS-latest",   "toolchain": "x86_64-apple-darwin",      "name": "macOS" },
+          { "os": "macos-13",       "toolchain": "x86_64-apple-darwin ",     "name": "macOS (x86)" },
+          { "os": "macos-latest",   "toolchain": "aarch64-apple-darwin",     "name": "macOS (ARM)" },
           { "os": "windows-latest", "toolchain": "x86_64-pc-windows-msvc",   "name": "Windows MSVC" },
         ]
         channel: [stable, beta, nightly]

--- a/src/megolm/group_session.rs
+++ b/src/megolm/group_session.rs
@@ -215,3 +215,20 @@ impl From<GroupSessionPickle> for GroupSession {
         Self { ratchet: pickle.ratchet, signing_key: pickle.signing_key, config: pickle.config }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::megolm::{GroupSession, SessionConfig};
+
+    #[test]
+    fn create_with_session_config() {
+        assert_eq!(
+            GroupSession::new(SessionConfig::version_1()).session_config(),
+            SessionConfig::version_1()
+        );
+        assert_eq!(
+            GroupSession::new(SessionConfig::version_2()).session_config(),
+            SessionConfig::version_2()
+        );
+    }
+}

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -471,8 +471,13 @@ impl From<&GroupSession> for InboundGroupSession {
 
 #[cfg(test)]
 mod test {
+    use olm_rs::outbound_group_session::OlmOutboundGroupSession;
+
     use super::InboundGroupSession;
-    use crate::megolm::{GroupSession, SessionConfig, SessionOrdering};
+    use crate::{
+        cipher::Cipher,
+        megolm::{GroupSession, SessionConfig, SessionKey, SessionOrdering},
+    };
 
     #[test]
     fn advance_inbound_session() {
@@ -568,6 +573,32 @@ mod test {
         assert!(merged.signing_key_verified);
         assert_eq!(merged.compare(&mut second_session), SessionOrdering::Better);
         assert_eq!(merged.compare(&mut first_session), SessionOrdering::Equal);
+    }
+
+    #[test]
+    fn verify_mac() {
+        let olm_session = OlmOutboundGroupSession::new();
+        let session_key = SessionKey::from_base64(&olm_session.session_key()).unwrap();
+        let message = olm_session.encrypt("Hello").as_str().try_into().unwrap();
+
+        let mut session = InboundGroupSession::new(&session_key, SessionConfig::version_1());
+        let ratchet = session.find_ratchet(0).unwrap();
+        let cipher = Cipher::new_megolm(ratchet.as_bytes());
+
+        session
+            .verify_mac(&cipher, &message)
+            .expect("Should verify MAC from matching outbound session");
+
+        let olm_session = OlmOutboundGroupSession::new();
+        let session_key = SessionKey::from_base64(&olm_session.session_key()).unwrap();
+
+        let mut session = InboundGroupSession::new(&session_key, SessionConfig::version_1());
+        let ratchet = session.find_ratchet(0).unwrap();
+        let cipher = Cipher::new_megolm(ratchet.as_bytes());
+
+        session
+            .verify_mac(&cipher, &message)
+            .expect_err("Should not verify MAC from different outbound session");
     }
 
     /// Test that [`InboundGroupSession::get_cipher_at`] correctly handles the

--- a/src/megolm/message.rs
+++ b/src/megolm/message.rs
@@ -45,9 +45,10 @@ pub struct MegolmMessage {
     pub(super) signature: Ed25519Signature,
 }
 
+const MESSAGE_TRUNCATED_SUFFIX_LENGTH: usize = Mac::TRUNCATED_LEN + Ed25519Signature::LENGTH;
+const MESSAGE_SUFFIX_LENGTH: usize = Mac::LENGTH + Ed25519Signature::LENGTH;
+
 impl MegolmMessage {
-    const MESSAGE_TRUNCATED_SUFFIX_LENGTH: usize = Mac::TRUNCATED_LEN + Ed25519Signature::LENGTH;
-    const MESSAGE_SUFFIX_LENGTH: usize = Mac::LENGTH + Ed25519Signature::LENGTH;
 
     /// The actual ciphertext of the message.
     pub fn ciphertext(&self) -> &[u8] {
@@ -274,8 +275,8 @@ impl TryFrom<&[u8]> for MegolmMessage {
         let version = *message.first().ok_or(DecodeError::MissingVersion)?;
 
         let suffix_length = match version {
-            VERSION => Self::MESSAGE_SUFFIX_LENGTH,
-            MAC_TRUNCATED_VERSION => Self::MESSAGE_TRUNCATED_SUFFIX_LENGTH,
+            VERSION => MESSAGE_SUFFIX_LENGTH,
+            MAC_TRUNCATED_VERSION => MESSAGE_TRUNCATED_SUFFIX_LENGTH,
             _ => return Err(DecodeError::InvalidVersion(VERSION, version)),
         };
 
@@ -344,5 +345,73 @@ impl ProtobufMegolmMessage {
             &self.ciphertext,
         ]
         .concat()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{cipher::Mac, megolm::{message::{MAC_TRUNCATED_VERSION, MESSAGE_SUFFIX_LENGTH, MESSAGE_TRUNCATED_SUFFIX_LENGTH, VERSION}, MegolmMessage}, DecodeError, Ed25519Signature};
+
+    #[cfg(feature = "low-level-api")]
+    use std::vec;
+
+    #[cfg(feature = "low-level-api")]
+    use crate::{Ed25519Keypair, Ed25519PublicKey};
+
+    #[test]
+    fn suffix_lengths() {
+        assert_eq!(MESSAGE_TRUNCATED_SUFFIX_LENGTH, Mac::TRUNCATED_LEN + Ed25519Signature::LENGTH);
+        assert_eq!(MESSAGE_SUFFIX_LENGTH, Mac::LENGTH + Ed25519Signature::LENGTH);
+    }
+
+    #[test]
+    fn message_to_short() {
+        let mut bytes = [1u8; 97];
+        bytes[0] = VERSION;
+        assert!(matches!(MegolmMessage::try_from(bytes.as_ref()), Err(DecodeError::MessageTooShort(_))));
+    }
+
+    #[test]
+    fn truncated_message_to_short() {
+        let mut bytes = [1u8; 73];
+        bytes[0] = MAC_TRUNCATED_VERSION;
+        assert!(matches!(MegolmMessage::try_from(bytes.as_ref()), Err(DecodeError::MessageTooShort(_))));
+    }
+
+    #[cfg(feature = "low-level-api")]
+    #[test]
+    fn add_valid_signature_succeeds() {
+        let mut message = MegolmMessage {
+            version: VERSION,
+            ciphertext: vec![],
+            message_index: 0,
+            mac: Mac([0u8; Mac::LENGTH]).into(),
+            signature: Ed25519Signature::from_slice(&[0; Ed25519Signature::LENGTH]).unwrap(),
+        };
+
+        let signing_key = Ed25519Keypair::new();
+        let signature = signing_key.sign(&message.to_signature_bytes());
+
+        println!("{:?}", signature.to_bytes());
+        message.add_signature(signature, signing_key.public_key()).expect("Should be able to add valid signature");
+        assert_eq!(message.signature, signature);
+    }
+
+    #[cfg(feature = "low-level-api")]
+    #[test]
+    fn add_invalid_signature_fails() {
+        let mut message = MegolmMessage {
+            version: VERSION,
+            ciphertext: vec![],
+            message_index: 0,
+            mac: Mac([0u8; Mac::LENGTH]).into(),
+            signature: Ed25519Signature::from_slice(&[0; Ed25519Signature::LENGTH]).unwrap(),
+        };
+
+        let public_key = Ed25519PublicKey::from_slice(&[0; 32]).unwrap();
+        let signature = Ed25519Signature::from_slice(&[1; Ed25519Signature::LENGTH]).unwrap();
+
+        message.add_signature(signature, public_key).expect_err("Should not be able to add invalid signature");
+        assert_ne!(message.signature, signature);
     }
 }

--- a/src/megolm/message.rs
+++ b/src/megolm/message.rs
@@ -406,7 +406,6 @@ mod test {
         let signing_key = Ed25519Keypair::new();
         let signature = signing_key.sign(&message.to_signature_bytes());
 
-        println!("{:?}", signature.to_bytes());
         message
             .add_signature(signature, signing_key.public_key())
             .expect("Should be able to add valid signature");

--- a/src/megolm/message.rs
+++ b/src/megolm/message.rs
@@ -49,7 +49,6 @@ const MESSAGE_TRUNCATED_SUFFIX_LENGTH: usize = Mac::TRUNCATED_LEN + Ed25519Signa
 const MESSAGE_SUFFIX_LENGTH: usize = Mac::LENGTH + Ed25519Signature::LENGTH;
 
 impl MegolmMessage {
-
     /// The actual ciphertext of the message.
     pub fn ciphertext(&self) -> &[u8] {
         &self.ciphertext
@@ -350,11 +349,20 @@ impl ProtobufMegolmMessage {
 
 #[cfg(test)]
 mod test {
-    use crate::{cipher::Mac, megolm::{message::{MAC_TRUNCATED_VERSION, MESSAGE_SUFFIX_LENGTH, MESSAGE_TRUNCATED_SUFFIX_LENGTH, VERSION}, MegolmMessage}, DecodeError, Ed25519Signature};
-
     #[cfg(feature = "low-level-api")]
     use std::vec;
 
+    use crate::{
+        cipher::Mac,
+        megolm::{
+            message::{
+                MAC_TRUNCATED_VERSION, MESSAGE_SUFFIX_LENGTH, MESSAGE_TRUNCATED_SUFFIX_LENGTH,
+                VERSION,
+            },
+            MegolmMessage,
+        },
+        DecodeError, Ed25519Signature,
+    };
     #[cfg(feature = "low-level-api")]
     use crate::{Ed25519Keypair, Ed25519PublicKey};
 
@@ -368,14 +376,20 @@ mod test {
     fn message_to_short() {
         let mut bytes = [1u8; 97];
         bytes[0] = VERSION;
-        assert!(matches!(MegolmMessage::try_from(bytes.as_ref()), Err(DecodeError::MessageTooShort(_))));
+        assert!(matches!(
+            MegolmMessage::try_from(bytes.as_ref()),
+            Err(DecodeError::MessageTooShort(_))
+        ));
     }
 
     #[test]
     fn truncated_message_to_short() {
         let mut bytes = [1u8; 73];
         bytes[0] = MAC_TRUNCATED_VERSION;
-        assert!(matches!(MegolmMessage::try_from(bytes.as_ref()), Err(DecodeError::MessageTooShort(_))));
+        assert!(matches!(
+            MegolmMessage::try_from(bytes.as_ref()),
+            Err(DecodeError::MessageTooShort(_))
+        ));
     }
 
     #[cfg(feature = "low-level-api")]
@@ -393,7 +407,9 @@ mod test {
         let signature = signing_key.sign(&message.to_signature_bytes());
 
         println!("{:?}", signature.to_bytes());
-        message.add_signature(signature, signing_key.public_key()).expect("Should be able to add valid signature");
+        message
+            .add_signature(signature, signing_key.public_key())
+            .expect("Should be able to add valid signature");
         assert_eq!(message.signature, signature);
     }
 
@@ -411,7 +427,9 @@ mod test {
         let public_key = Ed25519PublicKey::from_slice(&[0; 32]).unwrap();
         let signature = Ed25519Signature::from_slice(&[1; Ed25519Signature::LENGTH]).unwrap();
 
-        message.add_signature(signature, public_key).expect_err("Should not be able to add invalid signature");
+        message
+            .add_signature(signature, public_key)
+            .expect_err("Should not be able to add invalid signature");
         assert_ne!(message.signature, signature);
     }
 }

--- a/src/megolm/mod.rs
+++ b/src/megolm/mod.rs
@@ -66,11 +66,20 @@ mod test {
 
     use super::{ExportedSessionKey, GroupSession, InboundGroupSession, MegolmMessage};
     use crate::{
-        megolm::{GroupSessionPickle, InboundGroupSessionPickle, SessionConfig, SessionKey},
+        megolm::{
+            default_config, GroupSessionPickle, InboundGroupSessionPickle, SessionConfig,
+            SessionKey,
+        },
         run_corpus,
     };
 
     const PICKLE_KEY: [u8; 32] = [0u8; 32];
+
+    #[test]
+    fn default_config_is_v1() {
+        assert_eq!(default_config(), SessionConfig::version_1());
+        assert_ne!(default_config(), SessionConfig::default());
+    }
 
     #[test]
     fn encrypting() -> Result<()> {
@@ -290,6 +299,21 @@ mod test {
         assert_eq!(decrypted.message_index, 0);
 
         Ok(())
+    }
+
+    #[test]
+    fn message_getters() {
+        let mut session = GroupSession::new(SessionConfig::version_1());
+
+        // Get message with index 2
+        session.encrypt("foo bar 1");
+        session.encrypt("foo bar 2");
+        let message = session.encrypt("foo bar 3");
+
+        assert_eq!(message.ciphertext(), message.ciphertext);
+        assert_eq!(message.message_index(), message.message_index);
+        assert_eq!(message.mac(), message.mac.as_bytes());
+        assert_eq!(message.signature(), &message.signature);
     }
 
     #[test]

--- a/src/megolm/ratchet.rs
+++ b/src/megolm/ratchet.rs
@@ -270,4 +270,16 @@ mod tests {
         ratchet.counter = (1 << 24) - 1;
         ratchet.advance_to(1 << 24);
     }
+
+    #[test]
+    fn advance_forward_and_back() {
+        let mut ratchet = Ratchet::new();
+        assert_eq!(ratchet.counter, 0);
+        ratchet.advance();
+        assert_eq!(ratchet.counter, 1);
+        ratchet.advance();
+        assert_eq!(ratchet.counter, 2);
+        ratchet.advance_to(1);
+        assert_eq!(ratchet.counter, 1);
+    }
 }

--- a/src/megolm/session_config.rs
+++ b/src/megolm/session_config.rs
@@ -53,3 +53,14 @@ impl Default for SessionConfig {
         Self::version_2()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::megolm::{session_config::Version, SessionConfig};
+
+    #[test]
+    fn version() {
+        assert_eq!(SessionConfig::version_1().version(), Version::V1 as u8);
+        assert_eq!(SessionConfig::version_2().version(), Version::V2 as u8);
+    }
+}


### PR DESCRIPTION
This fixes the following issues:

```
MISSED   src/megolm/group_session.rs:80:9: replace GroupSession::session_config -> SessionConfig with Default::default() in 0.8s build + 3.1s test
MISSED   src/megolm/inbound_group_session.rs:289:47: replace < with == in InboundGroupSession::find_ratchet in 0.8s build + 3.1s test
MISSED   src/megolm/inbound_group_session.rs:302:9: replace InboundGroupSession::verify_mac -> Result<(), DecryptionError> with Ok(()) in 1.0s build + 3.1s test
MISSED   src/megolm/message.rs:133:9: replace MegolmMessage::add_signature -> Result<(), SignatureError> with Ok(()) in 0.8s build + 3.7s test
MISSED   src/megolm/message.rs:282:42: replace + with - in <impl TryFrom for MegolmMessage>::try_from in 0.8s build + 3.0s test
MISSED   src/megolm/message.rs:50:54: replace + with * in 0.8s build + 3.2s test
MISSED   src/megolm/message.rs:54:9: replace MegolmMessage::ciphertext -> &[u8] with Vec::leak(Vec::new()) in 0.8s build + 3.0s test
MISSED   src/megolm/message.rs:54:9: replace MegolmMessage::ciphertext -> &[u8] with Vec::leak(vec![0]) in 0.8s build + 3.4s test
MISSED   src/megolm/message.rs:54:9: replace MegolmMessage::ciphertext -> &[u8] with Vec::leak(vec![1]) in 0.8s build + 3.0s test
MISSED   src/megolm/message.rs:59:9: replace MegolmMessage::message_index -> u32 with 0 in 0.8s build + 2.9s test
MISSED   src/megolm/message.rs:59:9: replace MegolmMessage::message_index -> u32 with 1 in 0.8s build + 3.0s test
MISSED   src/megolm/message.rs:64:9: replace MegolmMessage::mac -> &[u8] with Vec::leak(Vec::new()) in 0.8s build + 3.1s test
MISSED   src/megolm/message.rs:64:9: replace MegolmMessage::mac -> &[u8] with Vec::leak(vec![0]) in 0.8s build + 3.2s test
MISSED   src/megolm/message.rs:64:9: replace MegolmMessage::mac -> &[u8] with Vec::leak(vec![1]) in 0.9s build + 3.3s test
MISSED   src/megolm/mod.rs:34:5: replace default_config -> SessionConfig with Default::default() in 0.8s build + 3.2s test
MISSED   src/megolm/ratchet.rs:218:31: replace < with == in Ratchet::advance_to in 0.7s build + 3.0s test
MISSED   src/megolm/session_config.rs:33:9: replace SessionConfig::version -> u8 with 0 in 0.8s build + 3.0s test
MISSED   src/megolm/session_config.rs:33:9: replace SessionConfig::version -> u8 with 1 in 0.8s build + 3.5s test
MISSED   src/megolm/session_keys.rs:141:9: replace <impl Zeroize for ExportedSessionKey>::zeroize with () in 1.0s build + 3.2s test
MISSED   src/megolm/session_keys.rs:291:9: replace <impl Zeroize for SessionKey>::zeroize with () in 0.9s build + 3.2s test
TIMEOUT  src/megolm/ratchet.rs:230:23: replace -= with += in Ratchet::advance_to in 0.8s build + 23.0s test
TIMEOUT  src/megolm/ratchet.rs:230:23: replace -= with /= in Ratchet::advance_to in 0.8s build + 23.0s test
```

This also gets us to +90% coverage. 🙂 

Relates to: #78