### PR TITLE
test(cipher): Add mutation tests

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -12,6 +12,8 @@ exclude_re = [
   # These cause olm/account tests to hang
   "RemoteChainKey::chain_index",
   "RemoteChainKey::advance",
+  # Intentionally returns Ok(()) in all cases
+  "replace Cipher::verify_truncated_mac -> Result<\\(\\), MacError> with Ok\\(\\(\\)\\)",
   # The constant value can't really be tested
   "src/olm/account/one_time_keys\\.rs.*replace \\* with \\+$",
 ]

--- a/src/cipher/mod.rs
+++ b/src/cipher/mod.rs
@@ -192,3 +192,18 @@ impl Cipher {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::{Cipher, Mac};
+    use crate::cipher::DecryptionError;
+
+    #[test]
+    fn decrypt_pickle_mac_missing() {
+        let cipher = Cipher::new(&[1u8; 32]);
+        assert!(matches!(
+            cipher.decrypt_pickle(&[2u8; Mac::TRUNCATED_LEN]),
+            Err(DecryptionError::MacMissing)
+        ));
+    }
+}


### PR DESCRIPTION
This fixes the following:

```
MISSED   src/cipher/mod.rs:146:29: replace < with == in Cipher::decrypt_pickle in 0.9s build + 3.1s test
MISSED   src/cipher/mod.rs:146:50: replace + with * in Cipher::decrypt_pickle in 0.9s build + 3.1s test
MISSED   src/cipher/mod.rs:146:50: replace + with - in Cipher::decrypt_pickle in 0.9s build + 3.1s test
MISSED   src/cipher/mod.rs:175:9: replace Cipher::verify_truncated_mac -> Result<(), MacError> with Ok(()) in 0.9s build + 3.5s test
```

Relates to: #78