### PR TITLE
chore: Fix clippy warnings about non-local impl definition

### DIFF
--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -19,7 +19,6 @@ use hmac::digest::MacError;
 use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 use thiserror::Error;
-use zeroize::Zeroize;
 
 use super::{
     default_config,
@@ -365,53 +364,61 @@ impl InboundGroupSession {
     pub fn from_pickle(pickle: InboundGroupSessionPickle) -> Self {
         Self::from(pickle)
     }
+}
 
-    #[cfg(feature = "libolm-compat")]
-    pub fn from_libolm_pickle(
-        pickle: &str,
-        pickle_key: &[u8],
-    ) -> Result<Self, crate::LibolmPickleError> {
-        use matrix_pickle::Decode;
+#[cfg(feature = "libolm-compat")]
+mod libolm_compat {
+    use matrix_pickle::Decode;
+    use zeroize::Zeroize;
 
-        use super::libolm::LibolmRatchetPickle;
-        use crate::utilities::unpickle_libolm;
+    use super::InboundGroupSession;
+    use crate::{
+        megolm::{libolm::LibolmRatchetPickle, SessionConfig},
+        utilities::unpickle_libolm,
+        Ed25519PublicKey,
+    };
 
-        #[derive(Zeroize, Decode)]
-        #[zeroize(drop)]
-        struct Pickle {
-            version: u32,
-            initial_ratchet: LibolmRatchetPickle,
-            latest_ratchet: LibolmRatchetPickle,
-            signing_key: [u8; 32],
-            signing_key_verified: bool,
+    #[derive(Zeroize, Decode)]
+    #[zeroize(drop)]
+    struct Pickle {
+        version: u32,
+        initial_ratchet: LibolmRatchetPickle,
+        latest_ratchet: LibolmRatchetPickle,
+        signing_key: [u8; 32],
+        signing_key_verified: bool,
+    }
+
+    impl TryFrom<Pickle> for InboundGroupSession {
+        type Error = crate::LibolmPickleError;
+
+        fn try_from(pickle: Pickle) -> Result<Self, Self::Error> {
+            // Removing the borrow doesn't work and clippy complains about
+            // this on nightly.
+            #[allow(clippy::needless_borrow)]
+            let initial_ratchet = (&pickle.initial_ratchet).into();
+            #[allow(clippy::needless_borrow)]
+            let latest_ratchet = (&pickle.latest_ratchet).into();
+            let signing_key = Ed25519PublicKey::from_slice(&pickle.signing_key)?;
+            let signing_key_verified = pickle.signing_key_verified;
+
+            Ok(Self {
+                initial_ratchet,
+                latest_ratchet,
+                signing_key,
+                signing_key_verified,
+                config: SessionConfig::version_1(),
+            })
         }
+    }
 
-        impl TryFrom<Pickle> for InboundGroupSession {
-            type Error = crate::LibolmPickleError;
-
-            fn try_from(pickle: Pickle) -> Result<Self, Self::Error> {
-                // Removing the borrow doesn't work and clippy complains about
-                // this on nightly.
-                #[allow(clippy::needless_borrow)]
-                let initial_ratchet = (&pickle.initial_ratchet).into();
-                #[allow(clippy::needless_borrow)]
-                let latest_ratchet = (&pickle.latest_ratchet).into();
-                let signing_key = Ed25519PublicKey::from_slice(&pickle.signing_key)?;
-                let signing_key_verified = pickle.signing_key_verified;
-
-                Ok(Self {
-                    initial_ratchet,
-                    latest_ratchet,
-                    signing_key,
-                    signing_key_verified,
-                    config: SessionConfig::version_1(),
-                })
-            }
+    impl InboundGroupSession {
+        pub fn from_libolm_pickle(
+            pickle: &str,
+            pickle_key: &[u8],
+        ) -> Result<Self, crate::LibolmPickleError> {
+            const PICKLE_VERSION: u32 = 2;
+            unpickle_libolm::<Pickle, _>(pickle, pickle_key, PICKLE_VERSION)
         }
-
-        const PICKLE_VERSION: u32 = 2;
-
-        unpickle_libolm::<Pickle, _>(pickle, pickle_key, PICKLE_VERSION)
     }
 }
 

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -32,7 +32,6 @@ use receiver_chain::ReceiverChain;
 use root_key::RemoteRootKey;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use zeroize::Zeroize;
 
 use super::{
     session_config::Version,
@@ -318,155 +317,167 @@ impl Session {
     pub fn from_pickle(pickle: SessionPickle) -> Self {
         pickle.into()
     }
+}
 
-    /// Create a [`Session`] object by unpickling a session pickle in libolm
-    /// legacy pickle format.
-    ///
-    /// Such pickles are encrypted and need to first be decrypted using
-    /// `pickle_key`.
-    #[cfg(feature = "libolm-compat")]
-    pub fn from_libolm_pickle(
-        pickle: &str,
-        pickle_key: &[u8],
-    ) -> Result<Self, crate::LibolmPickleError> {
-        use chain_key::ChainKey;
-        use matrix_pickle::Decode;
-        use message_key::RemoteMessageKey;
-        use ratchet::{Ratchet, RatchetKey};
-        use root_key::RootKey;
+#[cfg(feature = "libolm-compat")]
+mod libolm_compat {
+    use matrix_pickle::Decode;
+    use zeroize::Zeroize;
 
-        use crate::{types::Curve25519SecretKey, utilities::unpickle_libolm};
+    use super::{
+        chain_key::{ChainKey, RemoteChainKey},
+        double_ratchet::{DoubleRatchet, RatchetCount},
+        message_key::RemoteMessageKey,
+        ratchet::{Ratchet, RatchetKey, RemoteRatchetKey},
+        receiver_chain::ReceiverChain,
+        root_key::{RemoteRootKey, RootKey},
+        ChainStore, Session,
+    };
+    use crate::{
+        olm::{SessionConfig, SessionKeys},
+        types::Curve25519SecretKey,
+        utilities::unpickle_libolm,
+        Curve25519PublicKey,
+    };
 
-        #[derive(Debug, Decode, Zeroize)]
-        #[zeroize(drop)]
-        struct SenderChain {
-            public_ratchet_key: [u8; 32],
-            #[secret]
-            secret_ratchet_key: Box<[u8; 32]>,
-            chain_key: Box<[u8; 32]>,
-            chain_key_index: u32,
+    #[derive(Debug, Decode, Zeroize)]
+    #[zeroize(drop)]
+    struct SenderChain {
+        public_ratchet_key: [u8; 32],
+        #[secret]
+        secret_ratchet_key: Box<[u8; 32]>,
+        chain_key: Box<[u8; 32]>,
+        chain_key_index: u32,
+    }
+
+    #[derive(Debug, Decode, Zeroize)]
+    #[zeroize(drop)]
+    struct ReceivingChain {
+        public_ratchet_key: [u8; 32],
+        #[secret]
+        chain_key: Box<[u8; 32]>,
+        chain_key_index: u32,
+    }
+
+    impl From<&ReceivingChain> for ReceiverChain {
+        fn from(chain: &ReceivingChain) -> Self {
+            let ratchet_key = RemoteRatchetKey::from(chain.public_ratchet_key);
+            let chain_key = RemoteChainKey::from_bytes_and_index(
+                chain.chain_key.clone(),
+                chain.chain_key_index,
+            );
+
+            ReceiverChain::new(ratchet_key, chain_key, RatchetCount::unknown())
         }
+    }
 
-        #[derive(Debug, Decode, Zeroize)]
-        #[zeroize(drop)]
-        struct ReceivingChain {
-            public_ratchet_key: [u8; 32],
-            #[secret]
-            chain_key: Box<[u8; 32]>,
-            chain_key_index: u32,
+    #[derive(Debug, Decode, Zeroize)]
+    #[zeroize(drop)]
+    struct MessageKey {
+        ratchet_key: [u8; 32],
+        #[secret]
+        message_key: Box<[u8; 32]>,
+        index: u32,
+    }
+
+    impl From<&MessageKey> for RemoteMessageKey {
+        fn from(key: &MessageKey) -> Self {
+            RemoteMessageKey { key: key.message_key.clone(), index: key.index.into() }
         }
+    }
 
-        impl From<&ReceivingChain> for ReceiverChain {
-            fn from(chain: &ReceivingChain) -> Self {
-                let ratchet_key = RemoteRatchetKey::from(chain.public_ratchet_key);
-                let chain_key = RemoteChainKey::from_bytes_and_index(
-                    chain.chain_key.clone(),
-                    chain.chain_key_index,
+    #[derive(Decode)]
+    struct Pickle {
+        #[allow(dead_code)]
+        version: u32,
+        #[allow(dead_code)]
+        received_message: bool,
+        session_keys: SessionKeys,
+        #[secret]
+        root_key: Box<[u8; 32]>,
+        sender_chains: Vec<SenderChain>,
+        receiver_chains: Vec<ReceivingChain>,
+        message_keys: Vec<MessageKey>,
+    }
+
+    impl Drop for Pickle {
+        fn drop(&mut self) {
+            self.root_key.zeroize();
+            self.sender_chains.zeroize();
+            self.receiver_chains.zeroize();
+            self.message_keys.zeroize();
+        }
+    }
+
+    impl TryFrom<Pickle> for Session {
+        type Error = crate::LibolmPickleError;
+
+        fn try_from(pickle: Pickle) -> Result<Self, Self::Error> {
+            let mut receiving_chains = ChainStore::new();
+
+            for chain in &pickle.receiver_chains {
+                receiving_chains.push(chain.into())
+            }
+
+            for key in &pickle.message_keys {
+                let ratchet_key =
+                    RemoteRatchetKey::from(Curve25519PublicKey::from(key.ratchet_key));
+
+                if let Some(receiving_chain) = receiving_chains.find_ratchet(&ratchet_key) {
+                    receiving_chain.insert_message_key(key.into())
+                }
+            }
+
+            if let Some(chain) = pickle.sender_chains.first() {
+                // XXX: Passing in secret array as value.
+                let ratchet_key = RatchetKey::from(Curve25519SecretKey::from_slice(
+                    chain.secret_ratchet_key.as_ref(),
+                ));
+                let chain_key =
+                    ChainKey::from_bytes_and_index(chain.chain_key.clone(), chain.chain_key_index);
+
+                let root_key = RootKey::new(pickle.root_key.clone());
+
+                let ratchet = Ratchet::new_with_ratchet_key(root_key, ratchet_key);
+                let sending_ratchet = DoubleRatchet::from_ratchet_and_chain_key(ratchet, chain_key);
+
+                Ok(Self {
+                    session_keys: pickle.session_keys,
+                    sending_ratchet,
+                    receiving_chains,
+                    config: SessionConfig::version_1(),
+                })
+            } else if let Some(chain) = receiving_chains.get(0) {
+                let sending_ratchet = DoubleRatchet::inactive_from_libolm_pickle(
+                    RemoteRootKey::new(pickle.root_key.clone()),
+                    chain.ratchet_key(),
                 );
 
-                ReceiverChain::new(ratchet_key, chain_key, RatchetCount::unknown())
+                Ok(Self {
+                    session_keys: pickle.session_keys,
+                    sending_ratchet,
+                    receiving_chains,
+                    config: SessionConfig::version_1(),
+                })
+            } else {
+                Err(crate::LibolmPickleError::InvalidSession)
             }
         }
+    }
 
-        #[derive(Debug, Decode, Zeroize)]
-        #[zeroize(drop)]
-        struct MessageKey {
-            ratchet_key: [u8; 32],
-            #[secret]
-            message_key: Box<[u8; 32]>,
-            index: u32,
+    impl Session {
+        /// Create a [`Session`] object by unpickling a session pickle in libolm
+        /// legacy pickle format.
+        ///
+        /// Such pickles are encrypted and need to first be decrypted using
+        /// `pickle_key`.
+        pub fn from_libolm_pickle(
+            pickle: &str,
+            pickle_key: &[u8],
+        ) -> Result<Self, crate::LibolmPickleError> {
+            const PICKLE_VERSION: u32 = 1;
+            unpickle_libolm::<Pickle, _>(pickle, pickle_key, PICKLE_VERSION)
         }
-
-        impl From<&MessageKey> for RemoteMessageKey {
-            fn from(key: &MessageKey) -> Self {
-                RemoteMessageKey { key: key.message_key.clone(), index: key.index.into() }
-            }
-        }
-
-        #[derive(Decode)]
-        struct Pickle {
-            #[allow(dead_code)]
-            version: u32,
-            #[allow(dead_code)]
-            received_message: bool,
-            session_keys: SessionKeys,
-            #[secret]
-            root_key: Box<[u8; 32]>,
-            sender_chains: Vec<SenderChain>,
-            receiver_chains: Vec<ReceivingChain>,
-            message_keys: Vec<MessageKey>,
-        }
-
-        impl Drop for Pickle {
-            fn drop(&mut self) {
-                self.root_key.zeroize();
-                self.sender_chains.zeroize();
-                self.receiver_chains.zeroize();
-                self.message_keys.zeroize();
-            }
-        }
-
-        impl TryFrom<Pickle> for Session {
-            type Error = crate::LibolmPickleError;
-
-            fn try_from(pickle: Pickle) -> Result<Self, Self::Error> {
-                let mut receiving_chains = ChainStore::new();
-
-                for chain in &pickle.receiver_chains {
-                    receiving_chains.push(chain.into())
-                }
-
-                for key in &pickle.message_keys {
-                    let ratchet_key =
-                        RemoteRatchetKey::from(Curve25519PublicKey::from(key.ratchet_key));
-
-                    if let Some(receiving_chain) = receiving_chains.find_ratchet(&ratchet_key) {
-                        receiving_chain.insert_message_key(key.into())
-                    }
-                }
-
-                if let Some(chain) = pickle.sender_chains.first() {
-                    // XXX: Passing in secret array as value.
-                    let ratchet_key = RatchetKey::from(Curve25519SecretKey::from_slice(
-                        chain.secret_ratchet_key.as_ref(),
-                    ));
-                    let chain_key = ChainKey::from_bytes_and_index(
-                        chain.chain_key.clone(),
-                        chain.chain_key_index,
-                    );
-
-                    let root_key = RootKey::new(pickle.root_key.clone());
-
-                    let ratchet = Ratchet::new_with_ratchet_key(root_key, ratchet_key);
-                    let sending_ratchet =
-                        DoubleRatchet::from_ratchet_and_chain_key(ratchet, chain_key);
-
-                    Ok(Self {
-                        session_keys: pickle.session_keys,
-                        sending_ratchet,
-                        receiving_chains,
-                        config: SessionConfig::version_1(),
-                    })
-                } else if let Some(chain) = receiving_chains.get(0) {
-                    let sending_ratchet = DoubleRatchet::inactive_from_libolm_pickle(
-                        RemoteRootKey::new(pickle.root_key.clone()),
-                        chain.ratchet_key(),
-                    );
-
-                    Ok(Self {
-                        session_keys: pickle.session_keys,
-                        sending_ratchet,
-                        receiving_chains,
-                        config: SessionConfig::version_1(),
-                    })
-                } else {
-                    Err(crate::LibolmPickleError::InvalidSession)
-                }
-            }
-        }
-
-        const PICKLE_VERSION: u32 = 1;
-        unpickle_libolm::<Pickle, _>(pickle, pickle_key, PICKLE_VERSION)
     }
 }
 


### PR DESCRIPTION
This is an attempt at fixing the latest clippy warnings. The diff is quite large but in essence, I only moved the `from_libolm_pickle` methods into a separate module in the same file, broke out their contents and updated the imports.

I'm not sure if this is the best way but it appears to work and doesn't require using a myriad of `#[cfg(feature = "libolm-compat")]` annotations.

```
error: non-local `impl` definition, they should be avoided as they go against expectation
   --> src/megolm/group_session.rs:165:9
    |
165 | /         impl TryFrom<Pickle> for GroupSession {
166 | |             type Error = crate::LibolmPickleError;
167 | |
168 | |             fn try_from(pickle: Pickle) -> Result<Self, Self::Error> {
...   |
177 | |             }
178 | |         }
    | |_________^
    |
    = help: move this `impl` block outside the of the current associated function `from_libolm_pickle`
    = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
    = note: `-D non-local-definitions` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(non_local_definitions)]`

error: non-local `impl` definition, they should be avoided as they go against expectation
   --> src/megolm/inbound_group_session.rs:389:9
    |
389 | /         impl TryFrom<Pickle> for InboundGroupSession {
390 | |             type Error = crate::LibolmPickleError;
391 | |
392 | |             fn try_from(pickle: Pickle) -> Result<Self, Self::Error> {
...   |
409 | |             }
410 | |         }
    | |_________^
    |
    = help: move this `impl` block outside the of the current associated function `from_libolm_pickle`
    = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>

error: non-local `impl` definition, they should be avoided as they go against expectation
   --> src/olm/session/mod.rs:359:9
    |
359 | /         impl From<&ReceivingChain> for ReceiverChain {
360 | |             fn from(chain: &ReceivingChain) -> Self {
361 | |                 let ratchet_key = RemoteRatchetKey::from(chain.public_ratchet_key);
362 | |                 let chain_key = RemoteChainKey::from_bytes_and_index(
...   |
368 | |             }
369 | |         }
    | |_________^
    |
    = help: move this `impl` block outside the of the current associated function `from_libolm_pickle`
    = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>

error: non-local `impl` definition, they should be avoided as they go against expectation
   --> src/olm/session/mod.rs:380:9
    |
380 | /         impl From<&MessageKey> for RemoteMessageKey {
381 | |             fn from(key: &MessageKey) -> Self {
382 | |                 RemoteMessageKey { key: key.message_key.clone(), index: key.index.into() }
383 | |             }
384 | |         }
    | |_________^
    |
    = help: move this `impl` block outside the of the current associated function `from_libolm_pickle`
    = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>

error: non-local `impl` definition, they should be avoided as they go against expectation
   --> src/olm/session/mod.rs:409:9
    |
409 | /         impl TryFrom<Pickle> for Session {
410 | |             type Error = crate::LibolmPickleError;
411 | |
412 | |             fn try_from(pickle: Pickle) -> Result<Self, Self::Error> {
...   |
465 | |             }
466 | |         }
    | |_________^
    |
    = help: move this `impl` block outside the of the current associated function `from_libolm_pickle`
    = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
```