### PR TITLE
MSC4108 secure channel split encryption keys and monotonic nonces

### DIFF
--- a/src/secure_channel/messages.rs
+++ b/src/secure_channel/messages.rs
@@ -28,12 +28,12 @@ pub enum MessageDecodeError {
 }
 
 #[derive(Debug)]
-pub struct InitialMessage {
+pub struct LoginInitiateMessage {
     pub public_key: Curve25519PublicKey,
     pub ciphertext: Vec<u8>,
 }
 
-impl InitialMessage {
+impl LoginInitiateMessage {
     pub fn encode(&self) -> String {
         let ciphertext = base64_encode(&self.ciphertext);
         let key = self.public_key.to_base64();
@@ -72,7 +72,7 @@ impl Message {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SecureChannelMessage {
-    Initial(InitialMessage),
+    Initial(LoginInitiateMessage),
     Normal(Message),
 }
 
@@ -85,7 +85,7 @@ impl SecureChannelMessage {
     }
 
     pub fn decode(foo: &str) -> Result<Self, MessageDecodeError> {
-        if let Ok(message) = InitialMessage::decode(foo) {
+        if let Ok(message) = LoginInitiateMessage::decode(foo) {
             Ok(message.into())
         } else {
             Message::decode(foo).map(Into::into)
@@ -99,13 +99,13 @@ impl From<Message> for SecureChannelMessage {
     }
 }
 
-impl From<InitialMessage> for SecureChannelMessage {
-    fn from(value: InitialMessage) -> Self {
+impl From<LoginInitiateMessage> for SecureChannelMessage {
+    fn from(value: LoginInitiateMessage) -> Self {
         Self::Initial(value)
     }
 }
 
-impl Serialize for InitialMessage {
+impl Serialize for LoginInitiateMessage {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -116,7 +116,7 @@ impl Serialize for InitialMessage {
     }
 }
 
-impl<'de> Deserialize<'de> for InitialMessage {
+impl<'de> Deserialize<'de> for LoginInitiateMessage {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/src/secure_channel/messages.rs
+++ b/src/secure_channel/messages.rs
@@ -28,12 +28,12 @@ pub enum MessageDecodeError {
 }
 
 #[derive(Debug)]
-pub struct LoginInitiateMessage {
+pub struct InitialMessage {
     pub public_key: Curve25519PublicKey,
     pub ciphertext: Vec<u8>,
 }
 
-impl LoginInitiateMessage {
+impl InitialMessage {
     pub fn encode(&self) -> String {
         let ciphertext = base64_encode(&self.ciphertext);
         let key = self.public_key.to_base64();
@@ -72,7 +72,7 @@ impl Message {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SecureChannelMessage {
-    Initial(LoginInitiateMessage),
+    Initial(InitialMessage),
     Normal(Message),
 }
 
@@ -85,7 +85,7 @@ impl SecureChannelMessage {
     }
 
     pub fn decode(foo: &str) -> Result<Self, MessageDecodeError> {
-        if let Ok(message) = LoginInitiateMessage::decode(foo) {
+        if let Ok(message) = InitialMessage::decode(foo) {
             Ok(message.into())
         } else {
             Message::decode(foo).map(Into::into)
@@ -99,13 +99,13 @@ impl From<Message> for SecureChannelMessage {
     }
 }
 
-impl From<LoginInitiateMessage> for SecureChannelMessage {
-    fn from(value: LoginInitiateMessage) -> Self {
+impl From<InitialMessage> for SecureChannelMessage {
+    fn from(value: InitialMessage) -> Self {
         Self::Initial(value)
     }
 }
 
-impl Serialize for LoginInitiateMessage {
+impl Serialize for InitialMessage {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -116,7 +116,7 @@ impl Serialize for LoginInitiateMessage {
     }
 }
 
-impl<'de> Deserialize<'de> for LoginInitiateMessage {
+impl<'de> Deserialize<'de> for InitialMessage {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/src/secure_channel/mod.rs
+++ b/src/secure_channel/mod.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 use x25519_dalek::{EphemeralSecret, SharedSecret};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-pub use self::messages::{InitialMessage, Message, SecureChannelMessage};
+pub use self::messages::{LoginInitiateMessage, Message, SecureChannelMessage};
 use crate::Curve25519PublicKey;
 
 mod messages;
@@ -74,7 +74,7 @@ impl SecureChannel {
 
     pub fn create_inbound_channel(
         self,
-        message: &InitialMessage,
+        message: &LoginInitiateMessage,
     ) -> Result<ChannelCreationResult, SecureChannelError> {
         let our_public_key = self.public_key();
 
@@ -277,7 +277,7 @@ impl EstablishedSecureChannel {
 
         if self.initiator && nonce.as_slice() == &[0u8; 12] {
             // we are Device G, we send the LoginInitiateMessage
-            InitialMessage { ciphertext, public_key: self.our_public_key }.into()
+            LoginInitiateMessage { ciphertext, public_key: self.our_public_key }.into()
         } else {
             Message { ciphertext }.into()
         }

--- a/src/secure_channel/mod.rs
+++ b/src/secure_channel/mod.rs
@@ -20,7 +20,7 @@ use thiserror::Error;
 use x25519_dalek::{EphemeralSecret, SharedSecret};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-pub use self::messages::{LoginInitiateMessage, Message, SecureChannelMessage};
+pub use self::messages::{InitialMessage, Message, SecureChannelMessage};
 use crate::Curve25519PublicKey;
 
 mod messages;
@@ -74,7 +74,7 @@ impl SecureChannel {
 
     pub fn create_inbound_channel(
         self,
-        message: &LoginInitiateMessage,
+        message: &InitialMessage,
     ) -> Result<ChannelCreationResult, SecureChannelError> {
         let our_public_key = self.public_key();
 
@@ -277,7 +277,7 @@ impl EstablishedSecureChannel {
 
         if self.initiator && nonce.as_slice() == &[0u8; 12] {
             // we are Device G, we send the LoginInitiateMessage
-            LoginInitiateMessage { ciphertext, public_key: self.our_public_key }.into()
+            InitialMessage { ciphertext, public_key: self.our_public_key }.into()
         } else {
             Message { ciphertext }.into()
         }


### PR DESCRIPTION
For the attention of @dkasak.

Implement changes from matrix-org/matrix-spec-proposals@aa37af9