### PR TITLE
test: Enable mutation tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,65 @@ jobs:
 
       - name: Test
         run: cargo test --all-features
+
+  mutants-incremental:
+    name: Mutation tests (incremental)
+    needs: [clippy]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Relative diff
+        run: |
+          git branch -av
+          git diff origin/${{ github.base_ref }}.. | tee git.diff
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+
+      - name: Test
+        run: cargo mutants -vV --no-shuffle --in-place --in-diff git.diff
+
+      - name: Archive mutants.out
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mutants-incremental.out
+          path: mutants.out
+
+  mutants-full:
+    name: Mutation tests (full)
+    needs: [clippy]
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+
+      - name: Test
+        run: cargo mutants -vV --no-shuffle --in-place
+
+      - name: Archive mutants.out
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mutants-full.out
+          path: mutants.out
+      


### PR DESCRIPTION
Depends on: #142
Fixes: #78

This largely follows https://mutants.rs/ci.html and sets up incremental mutation tests on pull requests and full mutation tests on pushes. The full suite takes about half an hour on my laptop.