### PR TITLE
chore: Remove the end-to-end-encryption keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.6.0] - 2024-05-03
+## [0.6.0] - 2024-05-06
 
 ### Security Fixes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "A Rust implementation of Olm and Megolm"
 repository = "https://github.com/matrix-org/vodozemac"
 version = "0.6.0"
 edition = "2021"
-keywords = ["matrix", "chat", "messaging", "olm"]
+keywords = ["matrix", "chat", "messaging", "olm", "megolm", "double ratchet", "encryption", "E2EE", "cryptography"]
 license = "Apache-2.0"
 rust-version = "1.65"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "A Rust implementation of Olm and Megolm"
 repository = "https://github.com/matrix-org/vodozemac"
 version = "0.6.0"
 edition = "2021"
-keywords = ["matrix", "chat", "messaging", "olm", "end-to-end-encryption"]
+keywords = ["matrix", "chat", "messaging", "olm"]
 license = "Apache-2.0"
 rust-version = "1.65"
 


### PR DESCRIPTION
Apparently keywords need to have less than 20 characters.