### PR TITLE
fix: Use a constant-time Base64 encoder for secret key material

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ low-level-api = []
 aes = "0.8.4"
 arrayvec = { version = "0.7.4", features = ["serde"] }
 base64 = "0.22.1"
+base64ct = { version = "1.6.0", features = ["std", "alloc"] }
 cbc = { version = "0.1.2", features = ["std"] }
 chacha20poly1305 = "0.10.1"
 curve25519-dalek = { version = "4.1.2", default-features = false, features = ["zeroize"] }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -46,6 +46,8 @@ impl KeyId {
 pub enum KeyError {
     #[error("Failed decoding a public key from base64: {}", .0)]
     Base64Error(#[from] base64::DecodeError),
+    #[error("Failed to decode a private key from base64: {}", .0)]
+    Base64PrivateKey(#[from] base64ct::Error),
     #[error(
         "Failed decoding {key_type} key from base64: \
         Invalid number of bytes for {key_type}, expected {expected_length}, got {length}."


### PR DESCRIPTION
This patch fixes a security issue around a side-channel vulnerability[^1] when decoding secret key material using Base64.

In some circumstances an attacker can obtain information about secret key material via a controlled-channel and side-channel attack.

This patch avoids the side-channel by switching to the base64ct crate for the encoding, and more importantly, the decoding of secret key material.

[^1]: https://arxiv.org/abs/2108.04600
