### PR TITLE
refactor: Remove the pkcs7 crate from the list of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ getrandom = "0.2.15"
 hkdf = "0.12.4"
 hmac = "0.12.1"
 matrix-pickle = { version = "0.2.0" }
-pkcs7 = "0.4.1"
 prost = "0.13.1"
 rand = "0.8.5"
 serde = { version = "1.0.204", features = ["derive"] }


### PR DESCRIPTION
The pkcs7 crate has been deprecated[^1], the authors recommend us to switch to the block_padding crate instead.

Incidentally we're already using the block_padding crate for our pkcs7 needs as that one is re-exported by the AES crate. This means that the pkcs7 crate is already an unused dependency and we can just remove it.

This has been confirmed by cargo-udeps[^2] as well.

This closes: #162. 

[^1]: https://docs.rs/pkcs7/0.4.1/pkcs7/index.html#-deprecated-
[^2]: https://github.com/est31/cargo-udeps