### PR TITLE
Update the afl binary install command to the correct package

### DIFF
--- a/afl/README.md
+++ b/afl/README.md
@@ -15,7 +15,7 @@ After that afl-rs needs to be installed, the complete setup guide can be found
 with cargo:
 
 ```bash
-$ cargo install afl
+$ cargo install cargo-afl
 ```
 
 # Fuzzing


### PR DESCRIPTION
It seems like it at some point had been renamed to `cargo-afl`.

It seems to at least with `afl/olm-message-decoding` still work.

However the new cfg linting in rust is a bit unhappy about the fuzzing cfg flags:

```
warning: unexpected `cfg` condition name: `fuzzing`
  --> src/main.rs:29:11
   |
29 | #[cfg(not(fuzzing))]
   |           ^^^^^^^
   |
   = help: consider using a Cargo feature instead
   = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
            [lints.rust]
            unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
   = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(fuzzing)");` to the top of the `build.rs`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
```

I am not sure if it should be ignored or not.


Signed-Off-By: MTRNord <git@nordgedanken.dev>