### PR TITLE
Apply const keyword to various methods

### DIFF
--- a/src/cipher/key.rs
+++ b/src/cipher/key.rs
@@ -101,7 +101,7 @@ impl CipherKeys {
         Aes256Key::from_slice(self.aes_key.as_slice())
     }
 
-    pub fn mac_key(&self) -> &HmacSha256Key {
+    pub const fn mac_key(&self) -> &HmacSha256Key {
         &self.mac_key
     }
 

--- a/src/ecies/mod.rs
+++ b/src/ecies/mod.rs
@@ -116,7 +116,7 @@ struct EciesNonce {
 
 impl EciesNonce {
     /// Create a new [`EciesNonce`], starting the count from 0.
-    fn new() -> Self {
+    const fn new() -> Self {
         Self { inner: 0 }
     }
 
@@ -161,7 +161,7 @@ impl CheckCode {
     ///
     /// The bytes can be converted to a more user-friendly representation. The
     /// [`CheckCode::to_digit`] converts the bytes to a two-digit number.
-    pub fn as_bytes(&self) -> &[u8; 2] {
+    pub const fn as_bytes(&self) -> &[u8; 2] {
         &self.bytes
     }
 
@@ -179,7 +179,7 @@ impl CheckCode {
     ///
     /// println!("The check code of the IECS channel is: {check_code:02}");
     /// ```
-    pub fn to_digit(&self) -> u8 {
+    pub const fn to_digit(&self) -> u8 {
         let first = (self.bytes[0] % 10) * 10;
         let second = self.bytes[1] % 10;
 
@@ -472,7 +472,7 @@ impl EstablishedEcies {
     ///
     /// This public key needs to be sent to the other side so that it can
     /// complete the ECIES channel establishment.
-    pub fn public_key(&self) -> Curve25519PublicKey {
+    pub const fn public_key(&self) -> Curve25519PublicKey {
         self.our_public_key
     }
 
@@ -481,7 +481,7 @@ impl EstablishedEcies {
     ///
     /// This check code can be used to check that both sides of the session are
     /// indeed using the same shared secret.
-    pub fn check_code(&self) -> &CheckCode {
+    pub const fn check_code(&self) -> &CheckCode {
         &self.check_code
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,7 @@
     unused_qualifications,
     rust_2018_idioms
 )]
+#![warn(clippy::missing_const_for_fn)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod cipher;

--- a/src/megolm/group_session.rs
+++ b/src/megolm/group_session.rs
@@ -72,11 +72,11 @@ impl GroupSession {
     ///
     /// The message index is incremented each time a message is encrypted with
     /// the group session.
-    pub fn message_index(&self) -> u32 {
+    pub const fn message_index(&self) -> u32 {
         self.ratchet.index()
     }
 
-    pub fn session_config(&self) -> SessionConfig {
+    pub const fn session_config(&self) -> SessionConfig {
         self.config
     }
 

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -240,7 +240,7 @@ impl InboundGroupSession {
         })
     }
 
-    pub fn first_known_index(&self) -> u32 {
+    pub const fn first_known_index(&self) -> u32 {
         self.initial_ratchet.index()
     }
 

--- a/src/megolm/message.rs
+++ b/src/megolm/message.rs
@@ -55,7 +55,7 @@ impl MegolmMessage {
     }
 
     /// The index of the message that was used when the message was encrypted.
-    pub fn message_index(&self) -> u32 {
+    pub const fn message_index(&self) -> u32 {
         self.message_index
     }
 
@@ -65,7 +65,7 @@ impl MegolmMessage {
     }
 
     /// Get a reference to the megolm message's signature.
-    pub fn signature(&self) -> &Ed25519Signature {
+    pub const fn signature(&self) -> &Ed25519Signature {
         &self.signature
     }
 

--- a/src/megolm/mod.rs
+++ b/src/megolm/mod.rs
@@ -30,7 +30,7 @@ pub use message::MegolmMessage;
 pub use session_config::SessionConfig;
 pub use session_keys::{ExportedSessionKey, SessionKey, SessionKeyDecodeError};
 
-fn default_config() -> SessionConfig {
+const fn default_config() -> SessionConfig {
     SessionConfig::version_1()
 }
 

--- a/src/megolm/ratchet.rs
+++ b/src/megolm/ratchet.rs
@@ -145,15 +145,15 @@ impl Ratchet {
         ratchet
     }
 
-    pub fn from_bytes(bytes: Box<[u8; Self::RATCHET_LENGTH]>, counter: u32) -> Self {
+    pub const fn from_bytes(bytes: Box<[u8; Self::RATCHET_LENGTH]>, counter: u32) -> Self {
         Self { inner: RatchetBytes(bytes), counter }
     }
 
-    pub fn index(&self) -> u32 {
+    pub const fn index(&self) -> u32 {
         self.counter
     }
 
-    pub fn as_bytes(&self) -> &[u8; Self::RATCHET_LENGTH] {
+    pub const fn as_bytes(&self) -> &[u8; Self::RATCHET_LENGTH] {
         &self.inner.0
     }
 

--- a/src/megolm/session_config.rs
+++ b/src/megolm/session_config.rs
@@ -29,21 +29,21 @@ pub(super) enum Version {
 
 impl SessionConfig {
     /// Get the numeric version of this `SessionConfig`.
-    pub fn version(&self) -> u8 {
+    pub const fn version(&self) -> u8 {
         self.version as u8
     }
 
     /// Create a `SessionConfig` for the Megolm version 1. This version of
     /// Megolm uses AES-256 and HMAC with a truncated MAC to encrypt individual
     /// messages. The MAC will be truncated to 8 bytes.
-    pub fn version_1() -> Self {
+    pub const fn version_1() -> Self {
         SessionConfig { version: Version::V1 }
     }
 
     /// Create a `SessionConfig` for the Megolm version 2. This version of
     /// Megolm uses AES-256 and HMAC to encrypt individual messages. The MAC
     /// won't be truncated.
-    pub fn version_2() -> Self {
+    pub const fn version_2() -> Self {
         SessionConfig { version: Version::V2 }
     }
 }

--- a/src/olm/account/fallback_keys.rs
+++ b/src/olm/account/fallback_keys.rs
@@ -37,11 +37,11 @@ impl FallbackKey {
         Curve25519PublicKey::from(&self.key)
     }
 
-    pub fn secret_key(&self) -> &Curve25519SecretKey {
+    pub const fn secret_key(&self) -> &Curve25519SecretKey {
         &self.key
     }
 
-    pub fn key_id(&self) -> KeyId {
+    pub const fn key_id(&self) -> KeyId {
         self.key_id
     }
 
@@ -49,7 +49,7 @@ impl FallbackKey {
         self.published = true;
     }
 
-    pub fn published(&self) -> bool {
+    pub const fn published(&self) -> bool {
         self.published
     }
 }
@@ -62,7 +62,7 @@ pub(super) struct FallbackKeys {
 }
 
 impl FallbackKeys {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self { key_id: 0, fallback_key: None, previous_fallback_key: None }
     }
 

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -114,17 +114,17 @@ impl Account {
     }
 
     /// Get the IdentityKeys of this Account
-    pub fn identity_keys(&self) -> IdentityKeys {
+    pub const fn identity_keys(&self) -> IdentityKeys {
         IdentityKeys { ed25519: self.ed25519_key(), curve25519: self.curve25519_key() }
     }
 
     /// Get a reference to the account's public Ed25519 key
-    pub fn ed25519_key(&self) -> Ed25519PublicKey {
+    pub const fn ed25519_key(&self) -> Ed25519PublicKey {
         self.signing_key.public_key()
     }
 
     /// Get a reference to the account's public Curve25519 key
-    pub fn curve25519_key(&self) -> Curve25519PublicKey {
+    pub const fn curve25519_key(&self) -> Curve25519PublicKey {
         self.diffie_hellman_key.public_key()
     }
 
@@ -139,7 +139,7 @@ impl Account {
     /// **Note**: this differs from the libolm method of the same name, the
     /// libolm method returned the maximum amount of one-time keys the `Account`
     /// could hold and only half of those should be uploaded.
-    pub fn max_number_of_one_time_keys(&self) -> usize {
+    pub const fn max_number_of_one_time_keys(&self) -> usize {
         // We tell clients to upload a limited amount of one-time keys, this
         // amount is smaller than what we can store.
         //

--- a/src/olm/account/one_time_keys.rs
+++ b/src/olm/account/one_time_keys.rs
@@ -118,7 +118,7 @@ impl OneTimeKeys {
         self.insert_secret_key(key_id, key, false)
     }
 
-    pub(crate) fn secret_keys(&self) -> &BTreeMap<KeyId, Curve25519SecretKey> {
+    pub(crate) const fn secret_keys(&self) -> &BTreeMap<KeyId, Curve25519SecretKey> {
         &self.private_keys
     }
 

--- a/src/olm/messages/message.rs
+++ b/src/olm/messages/message.rs
@@ -44,12 +44,12 @@ pub struct Message {
 impl Message {
     /// The public part of the ratchet key, that was used when the message was
     /// encrypted.
-    pub fn ratchet_key(&self) -> Curve25519PublicKey {
+    pub const fn ratchet_key(&self) -> Curve25519PublicKey {
         self.ratchet_key
     }
 
     /// The index of the chain that was used when the message was encrypted.
-    pub fn chain_index(&self) -> u64 {
+    pub const fn chain_index(&self) -> u64 {
         self.chain_index
     }
 
@@ -59,12 +59,12 @@ impl Message {
     }
 
     /// The version of the Olm message.
-    pub fn version(&self) -> u8 {
+    pub const fn version(&self) -> u8 {
         self.version
     }
 
     /// Has the MAC been truncated in this Olm message.
-    pub fn mac_truncated(&self) -> bool {
+    pub const fn mac_truncated(&self) -> bool {
         self.version == MAC_TRUNCATED_VERSION
     }
 

--- a/src/olm/messages/mod.rs
+++ b/src/olm/messages/mod.rs
@@ -103,7 +103,7 @@ impl OlmMessage {
     }
 
     /// Get the type of the message.
-    pub fn message_type(&self) -> MessageType {
+    pub const fn message_type(&self) -> MessageType {
         match self {
             OlmMessage::Normal(_) => MessageType::Normal,
             OlmMessage::PreKey(_) => MessageType::PreKey,

--- a/src/olm/messages/pre_key.rs
+++ b/src/olm/messages/pre_key.rs
@@ -43,7 +43,7 @@ impl PreKeyMessage {
     /// receiver of the message. Should be used to establish a [`Session`].
     ///
     /// [`Session`]: crate::olm::Session
-    pub fn one_time_key(&self) -> Curve25519PublicKey {
+    pub const fn one_time_key(&self) -> Curve25519PublicKey {
         self.session_keys.one_time_key
     }
 
@@ -51,7 +51,7 @@ impl PreKeyMessage {
     /// sender of the message. Should be used to establish a [`Session`].
     ///
     /// [`Session`]: crate::olm::Session
-    pub fn base_key(&self) -> Curve25519PublicKey {
+    pub const fn base_key(&self) -> Curve25519PublicKey {
         self.session_keys.base_key
     }
 
@@ -59,7 +59,7 @@ impl PreKeyMessage {
     /// to establish a [`Session`]
     ///
     /// [`Session`]: crate::olm::Session
-    pub fn identity_key(&self) -> Curve25519PublicKey {
+    pub const fn identity_key(&self) -> Curve25519PublicKey {
         self.session_keys.identity_key
     }
 
@@ -70,7 +70,7 @@ impl PreKeyMessage {
     /// can be used to retrieve individual keys from this collection.
     ///
     /// [`Session`]: crate::olm::Session
-    pub fn session_keys(&self) -> SessionKeys {
+    pub const fn session_keys(&self) -> SessionKeys {
         self.session_keys
     }
 
@@ -82,7 +82,7 @@ impl PreKeyMessage {
     }
 
     /// The actual message that contains the ciphertext.
-    pub fn message(&self) -> &Message {
+    pub const fn message(&self) -> &Message {
         &self.message
     }
 
@@ -157,7 +157,7 @@ impl PreKeyMessage {
         PreKeyMessage::new(session_keys, message)
     }
 
-    pub(crate) fn new(session_keys: SessionKeys, message: Message) -> Self {
+    pub(crate) const fn new(session_keys: SessionKeys, message: Message) -> Self {
         Self { session_keys, message }
     }
 }

--- a/src/olm/session/chain_key.rs
+++ b/src/olm/session/chain_key.rs
@@ -61,11 +61,11 @@ pub(super) struct RemoteChainKey {
 }
 
 impl RemoteChainKey {
-    pub fn new(bytes: Box<[u8; 32]>) -> Self {
+    pub const fn new(bytes: Box<[u8; 32]>) -> Self {
         Self { key: bytes, index: 0 }
     }
 
-    pub fn chain_index(&self) -> u64 {
+    pub const fn chain_index(&self) -> u64 {
         self.index
     }
 
@@ -91,7 +91,7 @@ impl RemoteChainKey {
 }
 
 impl ChainKey {
-    pub fn new(bytes: Box<[u8; 32]>) -> Self {
+    pub const fn new(bytes: Box<[u8; 32]>) -> Self {
         Self { key: bytes, index: 0 }
     }
 
@@ -106,7 +106,7 @@ impl ChainKey {
         self.index += 1;
     }
 
-    pub fn index(&self) -> u64 {
+    pub const fn index(&self) -> u64 {
         self.index
     }
 

--- a/src/olm/session/double_ratchet.rs
+++ b/src/olm/session/double_ratchet.rs
@@ -301,11 +301,11 @@ pub enum RatchetCount {
 }
 
 impl RatchetCount {
-    pub fn new() -> RatchetCount {
+    pub const fn new() -> RatchetCount {
         RatchetCount::Known(0)
     }
 
-    pub fn unknown() -> RatchetCount {
+    pub const fn unknown() -> RatchetCount {
         RatchetCount::Unknown(())
     }
 

--- a/src/olm/session/message_key.rs
+++ b/src/olm/session/message_key.rs
@@ -56,7 +56,7 @@ impl Drop for RemoteMessageKey {
 }
 
 impl MessageKey {
-    pub fn new(key: Box<[u8; 32]>, ratchet_key: RatchetPublicKey, index: u64) -> Self {
+    pub const fn new(key: Box<[u8; 32]>, ratchet_key: RatchetPublicKey, index: u64) -> Self {
         Self { key, ratchet_key, index }
     }
 
@@ -107,11 +107,11 @@ impl MessageKey {
 }
 
 impl RemoteMessageKey {
-    pub fn new(key: Box<[u8; 32]>, index: u64) -> Self {
+    pub const fn new(key: Box<[u8; 32]>, index: u64) -> Self {
         Self { key, index }
     }
 
-    pub fn chain_index(&self) -> u64 {
+    pub const fn chain_index(&self) -> u64 {
         self.index
     }
 

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -93,7 +93,7 @@ impl ChainStore {
         self.inner.push(ratchet)
     }
 
-    fn is_empty(&self) -> bool {
+    const fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
@@ -219,7 +219,7 @@ impl Session {
     ///
     /// Used to decide if outgoing messages should be sent as normal or pre-key
     /// messages.
-    pub fn has_received_message(&self) -> bool {
+    pub const fn has_received_message(&self) -> bool {
         !self.receiving_chains.is_empty()
     }
 
@@ -245,11 +245,11 @@ impl Session {
     }
 
     /// Get the keys associated with this session.
-    pub fn session_keys(&self) -> SessionKeys {
+    pub const fn session_keys(&self) -> SessionKeys {
         self.session_keys
     }
 
-    pub fn session_config(&self) -> SessionConfig {
+    pub const fn session_config(&self) -> SessionConfig {
         self.config
     }
 
@@ -487,7 +487,7 @@ pub struct SessionPickle {
     config: SessionConfig,
 }
 
-fn default_config() -> SessionConfig {
+const fn default_config() -> SessionConfig {
     SessionConfig::version_1()
 }
 

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -98,7 +98,7 @@ impl ChainStore {
     }
 
     #[cfg(test)]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.inner.len()
     }
 

--- a/src/olm/session/ratchet.rs
+++ b/src/olm/session/ratchet.rs
@@ -129,7 +129,7 @@ impl Ratchet {
         Self { root_key, ratchet_key }
     }
 
-    pub fn new_with_ratchet_key(root_key: RootKey, ratchet_key: RatchetKey) -> Self {
+    pub const fn new_with_ratchet_key(root_key: RootKey, ratchet_key: RatchetKey) -> Self {
         Self { root_key, ratchet_key }
     }
 
@@ -140,7 +140,7 @@ impl Ratchet {
         (remote_root_key, remote_chain_key)
     }
 
-    pub fn ratchet_key(&self) -> &RatchetKey {
+    pub const fn ratchet_key(&self) -> &RatchetKey {
         &self.ratchet_key
     }
 }

--- a/src/olm/session/receiver_chain.rs
+++ b/src/olm/session/receiver_chain.rs
@@ -208,7 +208,7 @@ impl ReceiverChain {
     }
 
     #[cfg(feature = "libolm-compat")]
-    pub fn ratchet_key(&self) -> RemoteRatchetKey {
+    pub const fn ratchet_key(&self) -> RemoteRatchetKey {
         self.ratchet_key
     }
 

--- a/src/olm/session/root_key.rs
+++ b/src/olm/session/root_key.rs
@@ -64,7 +64,7 @@ fn kdf(
 }
 
 impl RemoteRootKey {
-    pub(super) fn new(bytes: Box<[u8; 32]>) -> Self {
+    pub(super) const fn new(bytes: Box<[u8; 32]>) -> Self {
         Self { key: bytes }
     }
 
@@ -89,7 +89,7 @@ impl RemoteRootKey {
 }
 
 impl RootKey {
-    pub(super) fn new(bytes: Box<[u8; 32]>) -> Self {
+    pub(super) const fn new(bytes: Box<[u8; 32]>) -> Self {
         Self { key: bytes }
     }
 

--- a/src/olm/session_config.rs
+++ b/src/olm/session_config.rs
@@ -29,21 +29,21 @@ pub(super) enum Version {
 
 impl SessionConfig {
     /// Get the numeric version of this `SessionConfig`.
-    pub fn version(&self) -> u8 {
+    pub const fn version(&self) -> u8 {
         self.version as u8
     }
 
     /// Create a `SessionConfig` for the Olm version 1. This version of Olm will
     /// use AES-256 and HMAC with a truncated MAC to encrypt individual
     /// messages. The MAC will be truncated to 8 bytes.
-    pub fn version_1() -> Self {
+    pub const fn version_1() -> Self {
         SessionConfig { version: Version::V1 }
     }
 
     /// Create a `SessionConfig` for the Olm version 2. This version of Olm will
     /// use AES-256 and HMAC to encrypt individual messages. The MAC won't be
     /// truncated.
-    pub fn version_2() -> Self {
+    pub const fn version_2() -> Self {
         SessionConfig { version: Version::V2 }
     }
 }

--- a/src/sas.rs
+++ b/src/sas.rs
@@ -162,7 +162,7 @@ impl SasBytes {
 
     /// Get the raw bytes of the short auth string that can be converted to an
     /// emoji, or decimal representation.
-    pub fn as_bytes(&self) -> &[u8; 6] {
+    pub const fn as_bytes(&self) -> &[u8; 6] {
         &self.bytes
     }
 
@@ -230,7 +230,7 @@ impl Sas {
     }
 
     /// Get the public key that can be used to establish a shared secret.
-    pub fn public_key(&self) -> Curve25519PublicKey {
+    pub const fn public_key(&self) -> Curve25519PublicKey {
         self.public_key
     }
 
@@ -389,13 +389,13 @@ impl EstablishedSas {
 
     /// Get the public key that was created by us, that was used to establish
     /// the shared secret.
-    pub fn our_public_key(&self) -> Curve25519PublicKey {
+    pub const fn our_public_key(&self) -> Curve25519PublicKey {
         self.our_public_key
     }
 
     /// Get the public key that was created by the other party, that was used to
     /// establish the shared secret.
-    pub fn their_public_key(&self) -> Curve25519PublicKey {
+    pub const fn their_public_key(&self) -> Curve25519PublicKey {
         self.their_public_key
     }
 

--- a/src/types/curve25519.rs
+++ b/src/types/curve25519.rs
@@ -95,11 +95,11 @@ impl Curve25519Keypair {
         Curve25519Keypair { secret_key, public_key }
     }
 
-    pub fn secret_key(&self) -> &Curve25519SecretKey {
+    pub const fn secret_key(&self) -> &Curve25519SecretKey {
         &self.secret_key
     }
 
-    pub fn public_key(&self) -> Curve25519PublicKey {
+    pub const fn public_key(&self) -> Curve25519PublicKey {
         self.public_key
     }
 }

--- a/src/types/ed25519.rs
+++ b/src/types/ed25519.rs
@@ -67,7 +67,7 @@ impl ExpandedSecretKey {
         })
     }
 
-    fn as_bytes(&self) -> &[u8; 64] {
+    const fn as_bytes(&self) -> &[u8; 64] {
         &self.source
     }
 
@@ -168,7 +168,7 @@ impl Ed25519Keypair {
     }
 
     /// Get the public Ed25519 key of this keypair.
-    pub fn public_key(&self) -> Ed25519PublicKey {
+    pub const fn public_key(&self) -> Ed25519PublicKey {
         self.public_key
     }
 

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -108,7 +108,7 @@ const MSB: u8 = 0b1000_0000;
 
 /// How many bytes an integer uses when being encoded as a VarInt.
 #[inline]
-fn required_encoded_space_unsigned(mut v: u64) -> usize {
+const fn required_encoded_space_unsigned(mut v: u64) -> usize {
     if v == 0 {
         return 1;
     }


### PR DESCRIPTION
This is based on the feedback given by the clippy [`missing_const_for_fn`](https://rust-lang.github.io/rust-clippy/master/index.html#/missing_const_for_fn) lint, which is still in nursery.

In a very non-scientific comparison, the `olm-message-decoding` afl fuzzer runs with ~0.5k to ~1k more executions per second on my PC.

I did not verify if any bindings rely on these to be not `const`. However, the test suite returned that everything is ok.

Signed-Off-By: MTRNord <git@nordgedanken.dev>