### PR TITLE
Add an editorconfig and vscode settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "rust-analyzer.checkOnSave.command": "clippy",
+    "rust-analyzer.cargo.features": "all",
+    "rust-analyzer.rustfmt": {
+        "extraArgs": ["+nightly"]
+    }
+}


### PR DESCRIPTION
The editorconfig and vscode settings for rust-analyzer have been established as cross-editor settings. At least nvim and vscode itself support them and people often times have trouble with our cargo fmt settings which require nightly.

This way, if a supported editor is used, no additional setup is required by the contributor.