### PR TITLE
Add a cargo deny configuration

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -1,0 +1,33 @@
+# https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+[graph]
+all-features = true
+exclude = [
+    # dev only dependency
+    "criterion"
+]
+
+[advisories]
+version = 2
+
+[licenses]
+version = 2
+allow = [
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "MIT",
+]
+exceptions = [
+    { allow = ["Unicode-DFS-2016"], crate = "unicode-ident" },
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+
+allow-git = [
+    "https://github.com/poljar/olm-rs",
+]

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,0 +1,13 @@
+name: Check for banned licenses
+on:
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check bans licenses sources


### PR DESCRIPTION
This allows us to use a single tool to check for security issues as well as licensing issues and that we don't have any git dependencies.