### PR TITLE
refactor: Remove Debug implementations for the libolm compat structs

### DIFF
--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -491,7 +491,7 @@ mod libolm {
         Curve25519PublicKey, Ed25519Keypair, KeyId,
     };
 
-    #[derive(Debug, Encode, Decode, Zeroize, ZeroizeOnDrop)]
+    #[derive(Encode, Decode, Zeroize, ZeroizeOnDrop)]
     struct OneTimeKey {
         key_id: u32,
         published: bool,
@@ -509,7 +509,7 @@ mod libolm {
         }
     }
 
-    #[derive(Debug, Zeroize, ZeroizeOnDrop)]
+    #[derive(Zeroize, ZeroizeOnDrop)]
     struct FallbackKeysArray {
         fallback_key: Option<OneTimeKey>,
         previous_fallback_key: Option<OneTimeKey>,

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -353,7 +353,7 @@ mod libolm_compat {
         Curve25519PublicKey,
     };
 
-    #[derive(Debug, Decode, Zeroize, ZeroizeOnDrop)]
+    #[derive(Decode, Zeroize, ZeroizeOnDrop)]
     struct SenderChain {
         public_ratchet_key: [u8; 32],
         #[secret]
@@ -362,7 +362,7 @@ mod libolm_compat {
         chain_key_index: u32,
     }
 
-    #[derive(Debug, Decode, Zeroize, ZeroizeOnDrop)]
+    #[derive(Decode, Zeroize, ZeroizeOnDrop)]
     struct ReceivingChain {
         public_ratchet_key: [u8; 32],
         #[secret]
@@ -382,7 +382,7 @@ mod libolm_compat {
         }
     }
 
-    #[derive(Debug, Decode, Zeroize, ZeroizeOnDrop)]
+    #[derive(Decode, Zeroize, ZeroizeOnDrop)]
     struct MessageKey {
         ratchet_key: [u8; 32],
         #[secret]


### PR DESCRIPTION
These structs contain private key material so they shouldn't have Debug implementations, even unused ones.

This closes: #70.