### PR TITLE
chore: Disable the const function lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ rust_2018_idioms = "deny"
 [lints.clippy]
 unwrap_used = "deny"
 mem_forget = "deny"
-missing_const_for_fn = "warn"
 
 [features]
 default = ["libolm-compat"]


### PR DESCRIPTION
There's no reason to constify every method we have that might be constified so let's disable the lint.