### PR TITLE
chore: Allow the usage of a git source for olm-sys

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -33,4 +33,5 @@ unknown-git = "deny"
 
 allow-git = [
     "https://github.com/poljar/olm-rs",
+    "https://github.com/poljar/olm-sys",
 ]

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -896,8 +896,8 @@ mod dehydrated_device {
             let one_time_keys: Vec<_> = account
                 .one_time_keys
                 .secret_keys()
-                .iter()
-                .map(|(_key_id, secret_key)| OneTimeKey { private_key: secret_key.to_bytes() })
+                .values()
+                .map(|secret_key| OneTimeKey { private_key: secret_key.to_bytes() })
                 .collect();
 
             let fallback_key =

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -662,7 +662,7 @@ mod test {
 
         let mut messages: Vec<messages::OlmMessage> = Vec::new();
         for i in 0..(MAX_MESSAGE_KEYS + 2) {
-            messages.push(bob_session.encrypt(format!("Message {}", i).as_str()).into());
+            messages.push(bob_session.encrypt(format!("Message {i}").as_str()).into());
         }
 
         // Decrypt last message
@@ -682,7 +682,7 @@ mod test {
         // Can decrypt all other messages
         for (i, message) in messages.iter().enumerate().skip(1).take(MAX_MESSAGE_KEYS) {
             assert_eq!(
-                format!("Message {}", i).as_bytes(),
+                format!("Message {i}").as_bytes(),
                 alice_session
                     .decrypt(message)
                     .expect("Should be able to decrypt remaining messages")
@@ -695,7 +695,7 @@ mod test {
         let (_, _, mut alice_session, bob_session) = session_and_libolm_pair().unwrap();
 
         for i in 0..(MAX_MESSAGE_GAP + 1) {
-            bob_session.encrypt(format!("Message {}", i).as_str());
+            bob_session.encrypt(format!("Message {i}").as_str());
         }
 
         let message = bob_session.encrypt("Message").into();


### PR DESCRIPTION
This was necessary because olm-sys started to fail to build because of the minimally required CMake version needed to be bumped.