### PR TITLE
test: Use assert_matches2 exclusively

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ zeroize = "1.8.1"
 
 [dev-dependencies]
 anyhow = "1.0.98"
-assert_matches = "1.5.0"
 assert_matches2 = "0.1.2"
 ntest = "0.9.3"
 olm-rs = "2.2.0"

--- a/src/cipher/mod.rs
+++ b/src/cipher/mod.rs
@@ -281,7 +281,7 @@ impl Cipher {
 
 #[cfg(test)]
 mod test {
-    use assert_matches::assert_matches;
+    use assert_matches2::assert_matches;
 
     use super::{Cipher, Mac};
     use crate::cipher::DecryptionError;

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -954,7 +954,7 @@ mod dehydrated_device {
 #[cfg(test)]
 mod test {
     use anyhow::{Context, Result, bail};
-    use assert_matches::assert_matches;
+    use assert_matches2::assert_matches;
     use matrix_pickle::{Decode, Encode};
     use olm_rs::{account::OlmAccount, session::OlmMessage as LibolmOlmMessage};
 
@@ -1517,14 +1517,14 @@ mod test {
         .expect("Should be able to rehydrate device");
 
         // make sure we can decrypt both messages
-        let prekey_message = assert_matches!(bob_olm_message, OlmMessage::PreKey(m) => m);
+        assert_matches!(bob_olm_message, OlmMessage::PreKey(prekey_message));
         let InboundCreationResult { session: alice_session, plaintext } = alice_rehydrated
             .create_inbound_session(bob.curve25519_key(), &prekey_message)
             .expect("Alice should be able to create an inbound session from Bob's pre-key message");
         assert_eq!(alice_session.session_id(), bob_session.session_id());
         assert_eq!(message.as_bytes(), plaintext);
 
-        let prekey_message = assert_matches!(carol_olm_message, OlmMessage::PreKey(m) => m);
+        assert_matches!(carol_olm_message, OlmMessage::PreKey(prekey_message));
         let InboundCreationResult { session: alice_session, plaintext } = alice_rehydrated
             .create_inbound_session(carol.curve25519_key(), &prekey_message)
             .expect(

--- a/src/olm/messages/message.rs
+++ b/src/olm/messages/message.rs
@@ -291,8 +291,7 @@ impl ProtoBufMessage {
 
 #[cfg(test)]
 mod test {
-    use assert_matches::assert_matches;
-    use assert_matches2::assert_let;
+    use assert_matches2::{assert_let, assert_matches};
 
     use super::Message;
     use crate::{

--- a/src/olm/messages/mod.rs
+++ b/src/olm/messages/mod.rs
@@ -152,7 +152,7 @@ impl From<MessageType> for usize {
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use assert_matches::assert_matches;
+    use assert_matches2::assert_matches;
     use olm_rs::session::OlmMessage as LibolmMessage;
     use serde_json::json;
 
@@ -224,7 +224,7 @@ mod tests {
         });
 
         let message: OlmMessage = serde_json::from_value(value.clone())?;
-        assert_matches!(message, OlmMessage::PreKey(_));
+        assert_matches!(message.clone(), OlmMessage::PreKey(_));
 
         let serialized = serde_json::to_value(message)?;
         assert_eq!(value, serialized, "The serialization cycle isn't a noop");
@@ -235,7 +235,7 @@ mod tests {
         });
 
         let message: OlmMessage = serde_json::from_value(value.clone())?;
-        assert_matches!(message, OlmMessage::Normal(_));
+        assert_matches!(message.clone(), OlmMessage::Normal(_));
 
         let serialized = serde_json::to_value(message)?;
         assert_eq!(value, serialized, "The serialization cycle isn't a noop");
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn from_parts() -> Result<()> {
         let message = OlmMessage::from_parts(0, base64_decode(PRE_KEY_MESSAGE)?.as_slice())?;
-        assert_matches!(message, OlmMessage::PreKey(_));
+        assert_matches!(message.clone(), OlmMessage::PreKey(_));
         assert_eq!(
             message.message_type(),
             MessageType::PreKey,
@@ -260,7 +260,7 @@ mod tests {
         );
 
         let message = OlmMessage::from_parts(1, base64_decode(MESSAGE)?.as_slice())?;
-        assert_matches!(message, OlmMessage::Normal(_));
+        assert_matches!(message.clone(), OlmMessage::Normal(_));
         assert_eq!(
             message.message_type(),
             MessageType::Normal,

--- a/src/olm/session/double_ratchet.rs
+++ b/src/olm/session/double_ratchet.rs
@@ -328,7 +328,7 @@ impl Debug for RatchetCount {
 
 #[cfg(test)]
 mod test {
-    use assert_matches::assert_matches;
+    use assert_matches2::assert_matches;
 
     use super::{
         ActiveDoubleRatchet, DoubleRatchet, DoubleRatchetState, InactiveDoubleRatchet, RatchetCount,
@@ -344,7 +344,7 @@ mod test {
 
         let message = "It's a secret to everybody";
         let olm_message = alice_session.encrypt(message);
-        let prekey_message = assert_matches!(olm_message, OlmMessage::PreKey(m) => m);
+        assert_matches!(olm_message, OlmMessage::PreKey(prekey_message));
 
         let alice_identity_key = alice.identity_keys().curve25519;
         let bob_session_creation_result = bob

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -521,7 +521,7 @@ impl From<SessionPickle> for Session {
 #[cfg(test)]
 mod test {
     use anyhow::{Result, bail};
-    use assert_matches::assert_matches;
+    use assert_matches2::assert_matches;
     use olm_rs::{
         account::OlmAccount,
         session::{OlmMessage, OlmSession},

--- a/src/olm/session/receiver_chain.rs
+++ b/src/olm/session/receiver_chain.rs
@@ -236,7 +236,7 @@ impl ReceiverChain {
 
 #[cfg(test)]
 mod test {
-    use assert_matches::assert_matches;
+    use assert_matches2::assert_matches;
 
     use super::MessageKeyStore;
     use crate::olm::{
@@ -256,7 +256,9 @@ mod test {
         let key = RemoteMessageKey::new(Box::new(key_bytes), chain_index);
         assert_matches!(store.get_message_key(chain_index), None);
         store.push(key);
-        assert_matches!(store.get_message_key(chain_index), Some(key) if *(key.key) == key_bytes && key.index == chain_index);
+        assert_matches!(store.get_message_key(chain_index), Some(key));
+        assert_eq!(key.key.as_ref(), &key_bytes);
+        assert_eq!(key.index, chain_index);
         store.remove_message_key(chain_index);
         assert_matches!(store.get_message_key(chain_index), None);
     }
@@ -295,10 +297,9 @@ mod test {
 
         assert_matches!(
             receiver_chain.find_message_key(MAX_MESSAGE_GAP + 1),
-            Err(DecryptionError::TooBigMessageGap(max_invalid_gap, MAX_MESSAGE_GAP)) =>
-            assert_eq!(max_invalid_gap, MAX_MESSAGE_GAP + 1)
+            Err(DecryptionError::TooBigMessageGap(max_invalid_gap, MAX_MESSAGE_GAP))
         );
-
+        assert_eq!(max_invalid_gap, MAX_MESSAGE_GAP + 1);
         assert_matches!(receiver_chain.find_message_key(MAX_MESSAGE_GAP), Ok(_));
     }
 }


### PR DESCRIPTION
As a continuation of #217, we don't really need to use both `assert_matches` crates and the `assert_matches2` crate is a bit more convenient.