### PR TITLE
chore: Fix the vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "rust-analyzer.checkOnSave.command": "clippy",
+    "rust-analyzer.check.command": "clippy",
     "rust-analyzer.cargo.features": "all",
     "rust-analyzer.rustfmt": {
         "extraArgs": ["+nightly"]


### PR DESCRIPTION
The rust-analyzer.checkOnSave.command setting was renamed to rust-analyzer.check.command.