### PR TITLE
Set up cargo-hack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,31 @@ jobs:
     - name: Clippy (no-default-features)
       run: cargo clippy --all-targets --no-default-features -- -D warnings
 
+  hack:
+    name: Check that each feature compiles independently
+    needs: [style]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+      with:
+        toolchain: stable
+
+    - name: Load cache
+      uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
+
+    - name: Install cargo-hack
+      uses: taiki-e/install-action@0eee80d37f55e834144deec670972c19e81a85b0
+      with:
+        tool: cargo-hack
+
+    - name: Check that our features compile
+      run: cargo hack check --each-feature --no-dev-deps
+
   test:
     name: ${{ matrix.target.name }} ${{ matrix.channel }}
     needs: [clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ default = ["libolm-compat"]
 js = ["getrandom/js"]
 strict-signatures = []
 libolm-compat = []
-insecure-pk-encryption = []
+insecure-pk-encryption = ["libolm-compat"]
 # The low-level-api feature exposes extra APIs that are only useful in advanced
 # use cases and require extra care to use.
 low-level-api = []


### PR DESCRIPTION
This allows us to check that our features work independently of each other.

This also includes a fix for one of our features that indeed did not work without another feature being enabled.