### PR TITLE
Add missing to_libolm_pickle implementations

### DIFF
--- a/src/megolm/group_session.rs
+++ b/src/megolm/group_session.rs
@@ -204,7 +204,7 @@ mod libolm_compat {
             Self {
                 version: 1,
                 ratchet: (&session.ratchet).into(),
-                ed25519_keypair: LibolmEd25519Keypair{
+                ed25519_keypair: LibolmEd25519Keypair {
                     private_key: Ed25519Keypair::expanded_secret_key(&session.signing_key),
                     public_key: session.signing_key.public_key().as_bytes().to_owned(),
                 },

--- a/src/megolm/group_session.rs
+++ b/src/megolm/group_session.rs
@@ -161,8 +161,9 @@ impl GroupSession {
 
     /// Pickle a [`GroupSession`] into a libolm pickle format.
     ///
-    /// This pickle can be restored using the [`GroupSession::from_libolm_pickle()`]
-    /// method, or can be used in the [`libolm`] C library.
+    /// This pickle can be restored using the
+    /// [`GroupSession::from_libolm_pickle()`] method, or can be used in the
+    /// [`libolm`] C library.
     ///
     /// The pickle will be encrypted using the pickle key.
     ///

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -445,8 +445,9 @@ impl InboundGroupSession {
 
     /// Pickle an [`InboundGroupSession`] into a libolm pickle format.
     ///
-    /// This pickle can be restored using the [`InboundGroupSession::from_libolm_pickle()`]
-    /// method, or can be used in the [`libolm`] C library.
+    /// This pickle can be restored using the
+    /// [`InboundGroupSession::from_libolm_pickle()`] method, or can be used
+    /// in the [`libolm`] C library.
     ///
     /// The pickle will be encrypted using the pickle key.
     ///

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -459,7 +459,9 @@ impl InboundGroupSession {
     /// [`libolm`]: https://gitlab.matrix.org/matrix-org/olm/
     #[cfg(feature = "libolm-compat")]
     pub fn to_libolm_pickle(&self, pickle_key: &[u8]) -> Result<String, crate::LibolmPickleError> {
-        use crate::{megolm::inbound_group_session::libolm_compat::Pickle, utilities::pickle_libolm};
+        use crate::{
+            megolm::inbound_group_session::libolm_compat::Pickle, utilities::pickle_libolm,
+        };
         pickle_libolm::<Pickle>(self.into(), pickle_key)
     }
 }

--- a/src/megolm/mod.rs
+++ b/src/megolm/mod.rs
@@ -36,16 +36,25 @@ const fn default_config() -> SessionConfig {
 
 #[cfg(feature = "libolm-compat")]
 mod libolm {
-    use matrix_pickle::Decode;
+    use matrix_pickle::{Decode, Encode};
     use zeroize::{Zeroize, ZeroizeOnDrop};
 
     use super::ratchet::Ratchet;
 
-    #[derive(Zeroize, ZeroizeOnDrop, Decode)]
+    #[derive(Zeroize, ZeroizeOnDrop, Encode, Decode)]
     pub(crate) struct LibolmRatchetPickle {
         #[secret]
         ratchet: Box<[u8; 128]>,
         index: u32,
+    }
+
+    impl From<&Ratchet> for LibolmRatchetPickle {
+        fn from(value: &Ratchet) -> Self {
+            LibolmRatchetPickle {
+                ratchet: Box::new(value.as_bytes().to_owned()),
+                index: value.index(),
+            }
+        }
     }
 
     impl From<&LibolmRatchetPickle> for Ratchet {

--- a/src/olm/session/chain_key.rs
+++ b/src/olm/session/chain_key.rs
@@ -77,6 +77,11 @@ impl RemoteChainKey {
         Self { key: bytes, index: index.into() }
     }
 
+    #[cfg(feature = "libolm-compat")]
+    pub fn to_bytes_and_index(&self) -> (Box<[u8; 32]>, u64) {
+        (self.key.clone(), self.index)
+    }
+
     pub fn advance(&mut self) {
         let output = advance(&self.key).into_bytes();
         self.key.copy_from_slice(output.as_slice());
@@ -101,6 +106,11 @@ impl ChainKey {
     #[cfg(feature = "libolm-compat")]
     pub fn from_bytes_and_index(bytes: Box<[u8; 32]>, index: u32) -> Self {
         Self { key: bytes, index: index.into() }
+    }
+
+    #[cfg(feature = "libolm-compat")]
+    pub fn to_bytes_and_index(&self) -> (Box<[u8; 32]>, u64) {
+        (self.key.clone(), self.index)
     }
 
     pub fn advance(&mut self) {

--- a/src/olm/session/double_ratchet.rs
+++ b/src/olm/session/double_ratchet.rs
@@ -23,8 +23,7 @@ use super::{
     receiver_chain::ReceiverChain,
     root_key::{RemoteRootKey, RootKey},
 };
-use crate::olm::session::ratchet::RatchetKey;
-use crate::olm::{messages::Message, shared_secret::Shared3DHSecret};
+use crate::olm::{messages::Message, session::ratchet::RatchetKey, shared_secret::Shared3DHSecret};
 
 /// The sender side of a double-ratchet implementation.
 ///

--- a/src/olm/session/double_ratchet.rs
+++ b/src/olm/session/double_ratchet.rs
@@ -23,8 +23,8 @@ use super::{
     receiver_chain::ReceiverChain,
     root_key::{RemoteRootKey, RootKey},
 };
-use crate::olm::{messages::Message, shared_secret::Shared3DHSecret};
 use crate::olm::session::ratchet::RatchetKey;
+use crate::olm::{messages::Message, shared_secret::Shared3DHSecret};
 
 /// The sender side of a double-ratchet implementation.
 ///
@@ -125,10 +125,8 @@ impl DoubleRatchet {
     #[cfg(feature = "libolm-compat")]
     pub fn root_key_bytes(&self) -> Box<[u8; 32]> {
         match &self.inner {
-            DoubleRatchetState::Inactive(ratchet) =>
-                ratchet.root_key.key.clone(),
-            DoubleRatchetState::Active(ratchet) =>
-                ratchet.active_ratchet.root_key().key.clone(),
+            DoubleRatchetState::Inactive(ratchet) => ratchet.root_key.key.clone(),
+            DoubleRatchetState::Active(ratchet) => ratchet.active_ratchet.root_key().key.clone(),
         }
     }
 
@@ -136,8 +134,9 @@ impl DoubleRatchet {
     pub fn to_ratchet_and_chain_key(&self) -> Option<(&RatchetKey, &ChainKey)> {
         match &self.inner {
             DoubleRatchetState::Inactive(_) => None,
-            DoubleRatchetState::Active(ratchet) =>
-                Some((ratchet.active_ratchet.ratchet_key(), &ratchet.symmetric_key_ratchet)),
+            DoubleRatchetState::Active(ratchet) => {
+                Some((ratchet.active_ratchet.ratchet_key(), &ratchet.symmetric_key_ratchet))
+            }
         }
     }
 

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -368,7 +368,7 @@ mod libolm_compat {
     };
     use crate::{
         Curve25519PublicKey,
-        olm::{SessionConfig, SessionKeys, RatchetPublicKey},
+        olm::{RatchetPublicKey, SessionConfig, SessionKeys},
         types::Curve25519SecretKey,
     };
 
@@ -464,16 +464,18 @@ mod libolm_compat {
                 }
             }
             let mut sender_chains = Vec::new();
-            if let Some((ratchet_key, chain_key)) = session.sending_ratchet.to_ratchet_and_chain_key() {
+            if let Some((ratchet_key, chain_key)) =
+                session.sending_ratchet.to_ratchet_and_chain_key()
+            {
                 let (chain_key, chain_key_index) = chain_key.to_bytes_and_index();
-                sender_chains.push(SenderChain{
+                sender_chains.push(SenderChain {
                     secret_ratchet_key: ratchet_key.clone().to_bytes(),
                     public_ratchet_key: RatchetPublicKey::from(ratchet_key).to_bytes(),
                     chain_key,
                     chain_key_index: chain_key_index.try_into().unwrap_or(u32::MAX),
                 })
             }
-            Pickle{
+            Pickle {
                 version: 1,
                 received_message: session.has_received_message(),
                 receiver_chains,

--- a/src/olm/session/ratchet.rs
+++ b/src/olm/session/ratchet.rs
@@ -44,6 +44,14 @@ pub(super) struct RatchetKey(Curve25519SecretKey);
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct RatchetPublicKey(Curve25519PublicKey);
 
+impl RatchetPublicKey {
+    /// Convert this public key to a byte array (for libolm pickling)
+    #[cfg(feature = "libolm-compat")]
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.0.to_bytes()
+    }
+}
+
 /// A ratchet key which was created by the other side.
 ///
 /// See [`RatchetKey`] for explanation about ratchet keys in general. Since this
@@ -58,6 +66,13 @@ impl Debug for RemoteRatchetKey {
     }
 }
 
+impl RemoteRatchetKey {
+    #[cfg(feature = "libolm-compat")]
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.0.to_bytes()
+    }
+}
+
 impl RatchetKey {
     pub fn new() -> Self {
         Self(Curve25519SecretKey::new())
@@ -65,6 +80,11 @@ impl RatchetKey {
 
     pub fn diffie_hellman(&self, other: &RemoteRatchetKey) -> SharedSecret {
         self.0.diffie_hellman(&other.0)
+    }
+
+    #[cfg(feature = "libolm-compat")]
+    pub fn to_bytes(&self) -> Box<[u8; 32]> {
+        self.0.to_bytes()
     }
 }
 
@@ -142,6 +162,11 @@ impl Ratchet {
 
     pub const fn ratchet_key(&self) -> &RatchetKey {
         &self.ratchet_key
+    }
+
+    #[cfg(feature = "libolm-compat")]
+    pub const fn root_key(&self) -> &RootKey {
+        &self.root_key
     }
 }
 

--- a/src/olm/session/receiver_chain.rs
+++ b/src/olm/session/receiver_chain.rs
@@ -60,6 +60,11 @@ impl MessageKeyStore {
     fn remove_message_key(&mut self, chain_index: u64) {
         self.inner.retain(|k| k.chain_index() != chain_index);
     }
+
+    #[cfg(feature = "libolm-compat")]
+    fn get_all(&self) -> &ArrayVec<RemoteMessageKey, MAX_MESSAGE_KEYS> {
+        &self.inner
+    }
 }
 
 impl Default for MessageKeyStore {
@@ -222,6 +227,16 @@ impl ReceiverChain {
     #[cfg(feature = "libolm-compat")]
     pub const fn ratchet_key(&self) -> RemoteRatchetKey {
         self.ratchet_key
+    }
+
+    #[cfg(feature = "libolm-compat")]
+    pub fn chain_key_and_index(&self) -> (Box<[u8; 32]>, u64) {
+        self.hkdf_ratchet.to_bytes_and_index()
+    }
+
+    #[cfg(feature = "libolm-compat")]
+    pub fn skipped_keys(&self) -> &ArrayVec<RemoteMessageKey, MAX_MESSAGE_KEYS> {
+        self.skipped_message_keys.get_all()
     }
 
     #[cfg(feature = "libolm-compat")]

--- a/src/olm/session_keys.rs
+++ b/src/olm/session_keys.rs
@@ -13,14 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use matrix_pickle::Decode;
+use matrix_pickle::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::{Curve25519PublicKey, utilities::base64_encode};
 
 /// The set of keys that were used to establish the Olm Session,
-#[derive(Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Decode)]
+#[derive(Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Encode, Decode)]
 pub struct SessionKeys {
     /// The long-term [`Curve25519PublicKey`] of the session initiator.
     pub identity_key: Curve25519PublicKey,

--- a/src/types/curve25519.rs
+++ b/src/types/curve25519.rs
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 use std::fmt::Display;
+use std::io::Write;
 
 use base64::decoded_len_estimate;
-use matrix_pickle::{Decode, DecodeError};
+use matrix_pickle::{Decode, DecodeError, Encode, EncodeError};
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use x25519_dalek::{EphemeralSecret, PublicKey, ReusableSecret, SharedSecret, StaticSecret};
@@ -115,6 +116,12 @@ impl Decode for Curve25519PublicKey {
         let key = <[u8; 32]>::decode(reader)?;
 
         Ok(Curve25519PublicKey::from(key))
+    }
+}
+
+impl Encode for Curve25519PublicKey {
+    fn encode(&self, writer: &mut impl Write) -> Result<usize, EncodeError> {
+        self.as_bytes().encode(writer)
     }
 }
 

--- a/src/types/curve25519.rs
+++ b/src/types/curve25519.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::Display;
-use std::io::Write;
+use std::{fmt::Display, io::Write};
 
 use base64::decoded_len_estimate;
 use matrix_pickle::{Decode, DecodeError, Encode, EncodeError};


### PR DESCRIPTION
I don't know Rust and haven't tested this yet