### PR TITLE
chore: Replace doc_auto_cfg with doc_cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@
 //! }
 //! ```
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod cipher;
 mod types;


### PR DESCRIPTION
As the former got merged into the later flag.