### PR TITLE
fix: default SessionConfig to version 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+<!-- next-header -->
+
+## [Unreleased] - ReleaseDate
+
+### Bug Fixes
+
+- [**BREAKING**] The `default()` implementations for `olm::SessionConfig` and
+  `megolm::SessionConfig` have been updated to generate a version 1
+  `SessionConfig`.
+  ([#287](https://github.com/matrix-org/vodozemac/pull/287)).
+
 ## [0.9.0] - 2025-01-31
 
 ### Features
 
-- Added support for [MSC3814](https://github.com/matrix-org/matrix-spec-proposals/pull/3814/),
-    allowing users to export an Olm Account in a serialized format. The
-    serialized account can be uploaded to a server for safekeeping until
-    needed.
-
+- Added support for
+  [MSC3814](https://github.com/matrix-org/matrix-spec-proposals/pull/3814/),
+  allowing users to export an Olm Account in a serialized format. The serialized
+  account can be uploaded to a server for safekeeping until needed.
 
 ## [0.8.1] - 2024-10-08
 

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -596,7 +596,7 @@ mod test {
 
         let session_key = session.export_at_first_known_index();
         let mut different_config =
-            InboundGroupSession::import(&session_key, SessionConfig::version_1());
+            InboundGroupSession::import(&session_key, SessionConfig::version_2());
 
         assert!(!session.connected(&mut different_config));
         assert!(!different_config.connected(&mut session));

--- a/src/megolm/mod.rs
+++ b/src/megolm/mod.rs
@@ -77,7 +77,7 @@ mod test {
     #[test]
     fn default_config_is_v1() {
         assert_eq!(default_config(), SessionConfig::version_1());
-        assert_ne!(default_config(), SessionConfig::default());
+        assert_eq!(default_config(), SessionConfig::default());
     }
 
     #[test]

--- a/src/megolm/session_config.rs
+++ b/src/megolm/session_config.rs
@@ -50,7 +50,7 @@ impl SessionConfig {
 
 impl Default for SessionConfig {
     fn default() -> Self {
-        Self::version_2()
+        Self::version_1()
     }
 }
 

--- a/src/olm/session_config.rs
+++ b/src/olm/session_config.rs
@@ -50,7 +50,7 @@ impl SessionConfig {
 
 impl Default for SessionConfig {
     fn default() -> Self {
-        Self::version_2()
+        Self::version_1()
     }
 }
 


### PR DESCRIPTION
The default() implementations of olm::SessionConfig and megolm::SessionConfig now create a version 1 SessionConfig instead of version 2.

Version 2 isn't specified anywhere yet, it shouldn't be used outside of experimental setups.

This closes https://github.com/matrix-org/vodozemac/issues/280.