### PR TITLE
Hazmat: expose Session constructor from non-Olm-derived root key material

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,11 @@ experimental-session-config = []
 # The low-level-api feature exposes extra APIs that are only useful in advanced
 # use cases and require extra care to use.
 low-level-api = []
+# Hazmat: expose a `Session` constructor that accepts pre-derived root/chain
+# /ratchet key material from a non-Olm handshake (e.g., Noise variants).
+# No new cryptographic logic — pure visibility + thin constructor over existing
+# internals. See `Session::from_root_key_material`.
+hazmat-expose-root-key = []
 
 [dependencies]
 aes = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,6 @@ experimental-session-config = []
 # The low-level-api feature exposes extra APIs that are only useful in advanced
 # use cases and require extra care to use.
 low-level-api = []
-# Hazmat: expose a `Session` constructor that accepts pre-derived root/chain
-# /ratchet key material from a non-Olm handshake (e.g., Noise variants).
-# No new cryptographic logic — pure visibility + thin constructor over existing
-# internals. See `Session::from_root_key_material`.
-hazmat-expose-root-key = []
 
 [dependencies]
 aes = "0.8.4"

--- a/src/olm/session/chain_key.rs
+++ b/src/olm/session/chain_key.rs
@@ -54,8 +54,8 @@ fn advance(key: &[u8; 32]) -> CtOutput<Hmac<Sha256>> {
 
 #[derive(Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub(super) struct ChainKey {
-    key: Box<[u8; 32]>,
-    index: u64,
+    pub(super) key: Box<[u8; 32]>,
+    pub(super) index: u64,
 }
 
 #[derive(Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]

--- a/src/olm/session/double_ratchet.rs
+++ b/src/olm/session/double_ratchet.rs
@@ -154,15 +154,11 @@ impl DoubleRatchet {
     #[cfg(feature = "low-level-api")]
     pub(super) fn active_sending_state(&self) -> Option<super::ActiveSendingState> {
         let DoubleRatchetState::Active(a) = &self.inner else { return None };
-        let mut root_key = [0u8; 32];
-        root_key.copy_from_slice(a.active_ratchet.root_key.key.as_ref());
-        let mut chain_key = [0u8; 32];
-        chain_key.copy_from_slice(a.symmetric_key_ratchet.key.as_ref());
         Some(super::ActiveSendingState {
-            root_key,
-            chain_key,
+            root_key: a.active_ratchet.root_key.key.clone(),
+            chain_key: a.symmetric_key_ratchet.key.clone(),
             chain_index: a.symmetric_key_ratchet.index,
-            ratchet_key: *a.active_ratchet.ratchet_key.0.to_bytes(),
+            ratchet_key: a.active_ratchet.ratchet_key.0.to_bytes(),
         })
     }
 

--- a/src/olm/session/double_ratchet.rs
+++ b/src/olm/session/double_ratchet.rs
@@ -24,6 +24,8 @@ use super::{
     root_key::{RemoteRootKey, RootKey},
 };
 use crate::olm::{EncryptionError, messages::Message, shared_secret::Shared3DHSecret};
+#[cfg(feature = "hazmat-expose-root-key")]
+use super::ratchet::RatchetKey;
 
 /// The sender side of a double-ratchet implementation.
 ///
@@ -123,6 +125,45 @@ impl DoubleRatchet {
         let ratchet = InactiveDoubleRatchet { root_key, ratchet_key, ratchet_count };
 
         Self { inner: ratchet.into() }
+    }
+
+    /// hazmat: build an active sender-side `DoubleRatchet` directly from raw
+    /// key material, bypassing the Olm 3DH handshake. Used by downstream
+    /// protocols that derive their own root key (e.g., Noise variants).
+    /// No new derivation — supplied values become the chain's keys verbatim.
+    #[cfg(feature = "hazmat-expose-root-key")]
+    pub(super) fn active_from_root_key_material(
+        root_key: RootKey,
+        chain_key: ChainKey,
+        ratchet_key: RatchetKey,
+    ) -> Self {
+        Self {
+            inner: ActiveDoubleRatchet {
+                parent_ratchet_key: None,
+                ratchet_count: RatchetCount::new(),
+                active_ratchet: Ratchet::new_with_ratchet_key(root_key, ratchet_key),
+                symmetric_key_ratchet: chain_key,
+            }
+            .into(),
+        }
+    }
+
+    /// hazmat: snapshot the active sender chain's raw bytes for equivalence
+    /// testing against an `Account`-derived session. Returns `None` if the
+    /// ratchet is inactive (no current sender chain).
+    #[cfg(feature = "hazmat-expose-root-key")]
+    pub(super) fn active_sending_state(&self) -> Option<super::ActiveSendingState> {
+        let DoubleRatchetState::Active(a) = &self.inner else { return None };
+        let mut root_key = [0u8; 32];
+        root_key.copy_from_slice(a.active_ratchet.root_key.key.as_ref());
+        let mut chain_key = [0u8; 32];
+        chain_key.copy_from_slice(a.symmetric_key_ratchet.key.as_ref());
+        Some(super::ActiveSendingState {
+            root_key,
+            chain_key,
+            chain_index: a.symmetric_key_ratchet.index,
+            ratchet_key: *a.active_ratchet.ratchet_key.0.to_bytes(),
+        })
     }
 
     pub fn advance(

--- a/src/olm/session/double_ratchet.rs
+++ b/src/olm/session/double_ratchet.rs
@@ -24,7 +24,7 @@ use super::{
     root_key::{RemoteRootKey, RootKey},
 };
 use crate::olm::{EncryptionError, messages::Message, shared_secret::Shared3DHSecret};
-#[cfg(feature = "hazmat-expose-root-key")]
+#[cfg(feature = "low-level-api")]
 use super::ratchet::RatchetKey;
 
 /// The sender side of a double-ratchet implementation.
@@ -131,7 +131,7 @@ impl DoubleRatchet {
     /// key material, bypassing the Olm 3DH handshake. Used by downstream
     /// protocols that derive their own root key (e.g., Noise variants).
     /// No new derivation — supplied values become the chain's keys verbatim.
-    #[cfg(feature = "hazmat-expose-root-key")]
+    #[cfg(feature = "low-level-api")]
     pub(super) fn active_from_root_key_material(
         root_key: RootKey,
         chain_key: ChainKey,
@@ -151,7 +151,7 @@ impl DoubleRatchet {
     /// hazmat: snapshot the active sender chain's raw bytes for equivalence
     /// testing against an `Account`-derived session. Returns `None` if the
     /// ratchet is inactive (no current sender chain).
-    #[cfg(feature = "hazmat-expose-root-key")]
+    #[cfg(feature = "low-level-api")]
     pub(super) fn active_sending_state(&self) -> Option<super::ActiveSendingState> {
         let DoubleRatchetState::Active(a) = &self.inner else { return None };
         let mut root_key = [0u8; 32];

--- a/src/olm/session/double_ratchet.rs
+++ b/src/olm/session/double_ratchet.rs
@@ -16,6 +16,8 @@ use std::fmt::{Debug, Formatter};
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "low-level-api")]
+use super::ratchet::RatchetKey;
 use super::{
     chain_key::ChainKey,
     message_key::MessageKey,
@@ -24,8 +26,6 @@ use super::{
     root_key::{RemoteRootKey, RootKey},
 };
 use crate::olm::{EncryptionError, messages::Message, shared_secret::Shared3DHSecret};
-#[cfg(feature = "low-level-api")]
-use super::ratchet::RatchetKey;
 
 /// The sender side of a double-ratchet implementation.
 ///

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -884,4 +884,38 @@ mod test {
         let message = message_key.encrypt(plaintext.as_bytes());
         assert_ne!(message.ciphertext, plaintext.as_bytes());
     }
+
+    #[test]
+    #[cfg(feature = "low-level-api")]
+    fn from_root_key_material_exposes_active_sending_state() {
+        use crate::{Curve25519SecretKey, olm::SessionKeys};
+
+        let session_keys = SessionKeys {
+            identity_key: Curve25519PublicKey::from_bytes([0xAA; 32]),
+            base_key: Curve25519PublicKey::from_bytes([0xBB; 32]),
+            one_time_key: Curve25519PublicKey::from_bytes([0xCC; 32]),
+        };
+
+        let root_key = [0x11u8; 32];
+        let chain_key = [0x22u8; 32];
+        let ratchet_key_secret = [0x33u8; 32];
+
+        let session = Session::from_root_key_material(
+            SessionConfig::version_2(),
+            session_keys,
+            root_key,
+            chain_key,
+            ratchet_key_secret,
+        );
+
+        let state = session
+            .active_sending_state()
+            .expect("a freshly constructed Session must have an active sending chain");
+
+        assert_eq!(state.root_key, root_key);
+        assert_eq!(state.chain_key, chain_key);
+        assert_eq!(state.chain_index, 0);
+        let expected_ratchet_key = *Curve25519SecretKey::from_slice(&ratchet_key_secret).to_bytes();
+        assert_eq!(state.ratchet_key, expected_ratchet_key);
+    }
 }

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -32,6 +32,8 @@ use receiver_chain::ReceiverChain;
 use root_key::RemoteRootKey;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+#[cfg(feature = "low-level-api")]
+use zeroize::Zeroize;
 
 use super::{
     SessionConfig,
@@ -190,29 +192,112 @@ impl Debug for Session {
     }
 }
 
-/// hazmat: raw key material for an active Olm sender chain. Companion to
-/// [`Session::from_root_key_material`] and [`Session::active_sending_state`],
-/// exposed for downstream protocols that build a `Session` from a non-Olm
-/// handshake (Noise variants, alternative KEMs).
+/// hazmat: a snapshot of the secret key material backing an active Olm sender
+/// chain.
+///
+/// This is the companion type to [`Session::from_root_key_material`] and is
+/// returned by [`Session::active_sending_state`]. It exists so that a
+/// [`Session`] bootstrapped from a non-Olm handshake can be compared for
+/// equivalence against an `Account`-derived [`Session`] — i.e. to assert that
+/// both sides agree on the root key, chain key and ratchet key once the
+/// handshake completes.
+///
+/// As with [`Session::from_root_key_material`], the only thing replaced here is
+/// the Olm 3DH handshake that normally seeds the root key; the Double Ratchet
+/// itself is untouched. See that constructor for the full rationale and an
+/// example.
+///
+/// The three 32-byte secrets are heap-allocated (boxed) and zeroized on drop,
+/// so moving the value around does not leave copies of the key material behind
+/// on the stack.
 #[cfg(feature = "low-level-api")]
 pub struct ActiveSendingState {
     /// Current root key `R_i` of the active sender chain.
-    pub root_key: [u8; 32],
+    pub root_key: Box<[u8; 32]>,
     /// Current chain key `C_{i,j}` of the active sender chain.
-    pub chain_key: [u8; 32],
+    pub chain_key: Box<[u8; 32]>,
     /// Index `j` within the current chain.
     pub chain_index: u64,
     /// Secret part of our local ratchet key `T_i`.
-    pub ratchet_key: [u8; 32],
+    pub ratchet_key: Box<[u8; 32]>,
+}
+
+#[cfg(feature = "low-level-api")]
+impl Drop for ActiveSendingState {
+    fn drop(&mut self) {
+        self.root_key.zeroize();
+        self.chain_key.zeroize();
+        self.ratchet_key.zeroize();
+    }
 }
 
 #[cfg(feature = "low-level-api")]
 impl Session {
-    /// hazmat: build a `Session` directly from raw active-sender key material
-    /// derived by a non-Olm handshake. No new derivation is performed —
-    /// supplied bytes become the active chain's keys verbatim. The supplied
-    /// [`SessionKeys`] is used solely for the session ID and pre-key message
-    /// envelope, with no further use of its contents.
+    /// hazmat: build a [`Session`] directly from raw active-sender key material
+    /// derived outside of Olm.
+    ///
+    /// The supplied `root_key`, `chain_key` and `ratchet_key_secret` become the
+    /// active sending chain's keys *verbatim* — no key derivation, KDF or AEAD
+    /// step is performed here. The supplied [`SessionKeys`] is used solely to
+    /// compute the session ID and to populate the pre-key message envelope; its
+    /// contents are never used as key material.
+    ///
+    /// # When to use this
+    ///
+    /// This is for downstream protocols that run their own authenticated key
+    /// exchange and want to layer vodozemac's audited Double Ratchet on top,
+    /// rather than vendoring a separate ratchet implementation. Typical cases
+    /// are Noise handshakes (for example a Noise `KK` exchange carried over a
+    /// transport such as Tor v3 onion services) or alternative / post-quantum
+    /// KEMs.
+    ///
+    /// This constructor *replaces only the Olm 3DH handshake*: the bytes you
+    /// pass in stand in for the secret that 3DH would normally produce. From
+    /// that point on the Double Ratchet works exactly as it does in a regular
+    /// Olm session — the symmetric-key ratchet advances per message and the DH
+    /// ratchet advances on each received reply.
+    ///
+    /// Both peers must independently derive identical `root_key`, `chain_key`
+    /// and `ratchet_key_secret` material and agree on which side owns the
+    /// initial sending chain; the other side decrypts the first message and the
+    /// DH ratchet converges from there.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use vodozemac::{
+    ///     Curve25519PublicKey,
+    ///     olm::{Session, SessionConfig, SessionKeys},
+    /// };
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// // Secret material produced by your own (non-Olm) handshake. These bytes
+    /// // become the active sender chain's keys verbatim.
+    /// let root_key = [0u8; 32];
+    /// let chain_key = [0u8; 32];
+    /// let ratchet_key_secret = [0u8; 32];
+    ///
+    /// // `SessionKeys` only feeds the session ID and the pre-key message
+    /// // envelope; its contents are not used as key material.
+    /// let session_keys = SessionKeys {
+    ///     identity_key: Curve25519PublicKey::from_bytes([1u8; 32]),
+    ///     base_key: Curve25519PublicKey::from_bytes([2u8; 32]),
+    ///     one_time_key: Curve25519PublicKey::from_bytes([3u8; 32]),
+    /// };
+    ///
+    /// let mut session = Session::from_root_key_material(
+    ///     SessionConfig::version_1(),
+    ///     session_keys,
+    ///     root_key,
+    ///     chain_key,
+    ///     ratchet_key_secret,
+    /// );
+    ///
+    /// // `session` is now a ready-to-use Olm sender.
+    /// let message = session.encrypt("Hello from a non-Olm handshake")?;
+    /// # let _ = message;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn from_root_key_material(
         config: SessionConfig,
         session_keys: SessionKeys,
@@ -912,10 +997,10 @@ mod test {
             .active_sending_state()
             .expect("a freshly constructed Session must have an active sending chain");
 
-        assert_eq!(state.root_key, root_key);
-        assert_eq!(state.chain_key, chain_key);
+        assert_eq!(*state.root_key, root_key);
+        assert_eq!(*state.chain_key, chain_key);
         assert_eq!(state.chain_index, 0);
         let expected_ratchet_key = *Curve25519SecretKey::from_slice(&ratchet_key_secret).to_bytes();
-        assert_eq!(state.ratchet_key, expected_ratchet_key);
+        assert_eq!(*state.ratchet_key, expected_ratchet_key);
     }
 }

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -194,7 +194,7 @@ impl Debug for Session {
 /// [`Session::from_root_key_material`] and [`Session::active_sending_state`],
 /// exposed for downstream protocols that build a `Session` from a non-Olm
 /// handshake (Noise variants, alternative KEMs).
-#[cfg(feature = "hazmat-expose-root-key")]
+#[cfg(feature = "low-level-api")]
 pub struct ActiveSendingState {
     /// Current root key `R_i` of the active sender chain.
     pub root_key: [u8; 32],
@@ -206,7 +206,7 @@ pub struct ActiveSendingState {
     pub ratchet_key: [u8; 32],
 }
 
-#[cfg(feature = "hazmat-expose-root-key")]
+#[cfg(feature = "low-level-api")]
 impl Session {
     /// hazmat: build a `Session` directly from raw active-sender key material
     /// derived by a non-Olm handshake. No new derivation is performed —

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -901,7 +901,7 @@ mod test {
         let ratchet_key_secret = [0x33u8; 32];
 
         let session = Session::from_root_key_material(
-            SessionConfig::version_2(),
+            SessionConfig::version_1(),
             session_keys,
             root_key,
             chain_key,

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -190,6 +190,51 @@ impl Debug for Session {
     }
 }
 
+/// hazmat: raw key material for an active Olm sender chain. Companion to
+/// [`Session::from_root_key_material`] and [`Session::active_sending_state`],
+/// exposed for downstream protocols that build a `Session` from a non-Olm
+/// handshake (Noise variants, alternative KEMs).
+#[cfg(feature = "hazmat-expose-root-key")]
+pub struct ActiveSendingState {
+    /// Current root key `R_i` of the active sender chain.
+    pub root_key: [u8; 32],
+    /// Current chain key `C_{i,j}` of the active sender chain.
+    pub chain_key: [u8; 32],
+    /// Index `j` within the current chain.
+    pub chain_index: u64,
+    /// Secret part of our local ratchet key `T_i`.
+    pub ratchet_key: [u8; 32],
+}
+
+#[cfg(feature = "hazmat-expose-root-key")]
+impl Session {
+    /// hazmat: build a `Session` directly from raw active-sender key material
+    /// derived by a non-Olm handshake. No new derivation is performed —
+    /// supplied bytes become the active chain's keys verbatim. The supplied
+    /// [`SessionKeys`] is used solely for the session ID and pre-key message
+    /// envelope, with no further use of its contents.
+    pub fn from_root_key_material(
+        config: SessionConfig,
+        session_keys: SessionKeys,
+        root_key: [u8; 32],
+        chain_key: [u8; 32],
+        ratchet_key_secret: [u8; 32],
+    ) -> Self {
+        let sending_ratchet = DoubleRatchet::active_from_root_key_material(
+            root_key::RootKey::new(Box::new(root_key)),
+            chain_key::ChainKey::new(Box::new(chain_key)),
+            ratchet::RatchetKey::from(crate::Curve25519SecretKey::from_slice(&ratchet_key_secret)),
+        );
+        Self { session_keys, sending_ratchet, receiving_chains: ChainStore::new(), config }
+    }
+
+    /// hazmat: read out the active sender chain's raw key material for
+    /// equivalence testing. Returns `None` if there is no active sender chain.
+    pub fn active_sending_state(&self) -> Option<ActiveSendingState> {
+        self.sending_ratchet.active_sending_state()
+    }
+}
+
 impl Session {
     pub(super) fn new(
         config: SessionConfig,

--- a/src/olm/session/ratchet.rs
+++ b/src/olm/session/ratchet.rs
@@ -38,7 +38,7 @@ use crate::{Curve25519PublicKey, types::Curve25519SecretKey};
 /// ratchet keys as `T`<sub>`i`</sub>.
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(transparent)]
-pub(super) struct RatchetKey(Curve25519SecretKey);
+pub(super) struct RatchetKey(pub(super) Curve25519SecretKey);
 
 /// The public part of a [`RatchetKey`].
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -118,8 +118,8 @@ impl From<&RatchetKey> for RatchetPublicKey {
 /// `R`<sub>`i`</sub>, and our own ratchet key `T`<sub>`i`</sub>.
 #[derive(Serialize, Deserialize, Clone)]
 pub(super) struct Ratchet {
-    root_key: RootKey,
-    ratchet_key: RatchetKey,
+    pub(super) root_key: RootKey,
+    pub(super) ratchet_key: RatchetKey,
 }
 
 impl Ratchet {


### PR DESCRIPTION
Closes #334.

Implements the proposal from #334: a feature-gated `Session::from_root_key_material` constructor plus a companion `Session::active_sending_state` accessor, enabling downstream projects to reuse vodozemac's audited Double Ratchet on top of non-Olm handshakes (Noise variants, alternative PQ KEMs, experimental transports).

## Summary

- New `Session::from_root_key_material(config, session_keys, root_key, chain_key, ratchet_key_secret)` constructor — composes existing internals (`Ratchet::new_with_ratchet_key`, `RootKey::new`, `ChainKey::new`, `Curve25519SecretKey::from_slice`); **no new cryptographic logic**.
- New `Session::active_sending_state()` returning a public `ActiveSendingState { root_key, chain_key, chain_index, ratchet_key }` — strictly for equivalence-testing against `Account`-derived sessions.
- Five field-visibility flips from private → `pub(super)` inside the `session` module, so cross-module reads in `double_ratchet.rs` don't need extra accessor wrappers.
- 96 insertions / 5 deletions across 5 files (`Cargo.toml`, `src/olm/session/chain_key.rs`, `src/olm/session/double_ratchet.rs`, `src/olm/session/mod.rs`, `src/olm/session/ratchet.rs`).

## Properties

- **Zero impact when the feature is off** — default `cargo build` produces identical artifacts to vanilla 0.10.0.
- No new `unsafe`, no new dependencies, no new derivation / KDF / AEAD calls.
- Existing test suite passes with the feature enabled (137 lib + 10 doc tests).
- `missing_docs`, `unsafe_code`, `unwrap_used`, `expect_used`, `panic` all pass with `-D warnings`.

## Adjustments per review feedback

Per @poljar's response on the issue (https://github.com/matrix-org/vodozemac/issues/334#issuecomment-4405541573):

- Will move the gate from a new `hazmat-expose-root-key` feature to the existing `low-level-api` feature — happy to push that as a follow-up commit on this branch.
- Keeping the constructor and the extractor under a single feature (not splitting into `hazmat-from-root-key` / `hazmat-extract-state`).

Naming, granularity, or any other details are open to further adjustment during review.

## Use case

Two-party peer-to-peer messenger over Tor v3 onion services. Each peer runs `arti` for inbound onion service + outbound dial; handshake is Noise `KK` over an in-person-exchanged static identity (QR code). The goal is to put vodozemac's audited Double Ratchet on top, rather than vendor an unaudited Rust DR implementation.