### PR TITLE
Use rand_core::OsRng directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file.
 - Add a new `olm::Session` constructor which allows the 3DH step to be skipped.
   ([#341](https://github.com/matrix-org/vodozemac/pull/341))
 
+### Refactor
+
+- Use `rand_core::OsRng` directly for cryptographic randomness.
+  ([#363](https://github.com/matrix-org/vodozemac/pull/363))
+
 ## [0.10.0] - 2026-04-13
 
 ### Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ hkdf = "0.12.4"
 hmac = "0.12.1"
 matrix-pickle = { version = "0.2.1" }
 prost = "0.14.3"
-rand = "0.8.5"
+rand_core = { version = "0.6.4", features = ["getrandom"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_bytes = "0.11.17"
 serde_json = "1.0.140"

--- a/src/ecies/mod.rs
+++ b/src/ecies/mod.rs
@@ -85,7 +85,7 @@
 
 use chacha20poly1305::{ChaCha20Poly1305, Key as Chacha20Key, KeyInit, Nonce, aead::Aead};
 use hkdf::Hkdf;
-use rand::thread_rng;
+use rand_core::OsRng;
 use sha2::Sha512;
 use thiserror::Error;
 use x25519_dalek::{EphemeralSecret, SharedSecret};
@@ -244,7 +244,7 @@ impl Ecies {
     /// The application info will be used to derive the various secrets and
     /// provide domain separation.
     pub fn with_info(info: &str) -> Self {
-        let rng = thread_rng();
+        let rng = OsRng;
         let secret_key = EphemeralSecret::random_from_rng(rng);
         let application_info_prefix = info.to_owned();
 

--- a/src/megolm/ratchet.rs
+++ b/src/megolm/ratchet.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use hmac::{Hmac, Mac as _};
-use rand::{RngCore, thread_rng};
+use rand_core::{OsRng, RngCore};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Sha256, digest::CtOutput};
 use subtle::{Choice, ConstantTimeEq};
@@ -139,7 +139,7 @@ impl Ratchet {
     const LAST_RATCHET_INDEX: usize = Self::RATCHET_PART_COUNT - 1;
 
     pub fn new() -> Self {
-        let mut rng = thread_rng();
+        let mut rng = OsRng;
 
         let mut ratchet =
             Self { inner: RatchetBytes(Box::new([0u8; Self::RATCHET_LENGTH])), counter: 0 };

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -21,7 +21,7 @@ use chacha20poly1305::{
     ChaCha20Poly1305,
     aead::{Aead, AeadCore, KeyInit},
 };
-use rand::thread_rng;
+use rand_core::OsRng;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use zeroize::Zeroize;
@@ -520,7 +520,7 @@ impl Account {
             .map_err(|e| DehydratedDeviceError::LibolmPickle(LibolmPickleError::Encode(e)))?;
 
         let cipher = ChaCha20Poly1305::new(key.into());
-        let rng = thread_rng();
+        let rng = OsRng;
         let nonce = ChaCha20Poly1305::generate_nonce(rng);
         let ciphertext = cipher.encrypt(&nonce, encoded.as_slice());
 

--- a/src/sas.rs
+++ b/src/sas.rs
@@ -53,7 +53,7 @@
 
 use hkdf::Hkdf;
 use hmac::{Hmac, Mac as _, digest::MacError};
-use rand::thread_rng;
+use rand_core::OsRng;
 use sha2::Sha256;
 use thiserror::Error;
 use x25519_dalek::{EphemeralSecret, SharedSecret};
@@ -221,7 +221,7 @@ impl Sas {
     /// This creates an ephemeral curve25519 keypair that can be used to
     /// establish a shared secret.
     pub fn new() -> Self {
-        let rng = thread_rng();
+        let rng = OsRng;
 
         let secret_key = EphemeralSecret::random_from_rng(rng);
         let public_key = Curve25519PublicKey::from(&secret_key);

--- a/src/types/curve25519.rs
+++ b/src/types/curve25519.rs
@@ -16,7 +16,7 @@ use std::fmt::Display;
 
 use base64::decoded_len_estimate;
 use matrix_pickle::{Decode, DecodeError};
-use rand::thread_rng;
+use rand_core::OsRng;
 use serde::{Deserialize, Serialize};
 use x25519_dalek::{EphemeralSecret, PublicKey, ReusableSecret, SharedSecret, StaticSecret};
 use zeroize::Zeroize;
@@ -32,7 +32,7 @@ pub struct Curve25519SecretKey(Box<StaticSecret>);
 impl Curve25519SecretKey {
     /// Generate a new, random, Curve25519SecretKey.
     pub fn new() -> Self {
-        let rng = thread_rng();
+        let rng = OsRng;
 
         Self(Box::new(StaticSecret::random_from_rng(rng)))
     }

--- a/src/types/ed25519.rs
+++ b/src/types/ed25519.rs
@@ -20,7 +20,7 @@ use curve25519_dalek::EdwardsPoint;
 use ed25519_dalek::{
     PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH, Signature, Signer, SigningKey, VerifyingKey,
 };
-use rand::thread_rng;
+use rand_core::OsRng;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_bytes::{ByteBuf as SerdeByteBuf, Bytes as SerdeBytes};
 use sha2::Sha512;
@@ -127,7 +127,7 @@ impl<'d> Deserialize<'d> for ExpandedSecretKey {
 impl Ed25519Keypair {
     /// Create a new, random, `Ed25519Keypair`.
     pub fn new() -> Self {
-        let mut rng = thread_rng();
+        let mut rng = OsRng;
         let signing_key = SigningKey::generate(&mut rng);
 
         Self {
@@ -206,7 +206,7 @@ impl Ed25519SecretKey {
 
     /// Create a new random `Ed25519SecretKey`.
     pub fn new() -> Self {
-        let mut rng = thread_rng();
+        let mut rng = OsRng;
         let signing_key = SigningKey::generate(&mut rng);
         let key = Box::new(signing_key);
 


### PR DESCRIPTION
## Summary

This replaces Vodozemac's direct `rand` dependency with a direct `rand_core` dependency and uses `rand_core::OsRng` at the production entropy call sites.

Updated call sites:

- Curve25519 key generation
- Ed25519 key generation
- ECIES ephemeral key generation
- SAS ephemeral key generation
- dehydrated-device nonce generation
- Megolm ratchet random bytes

This keeps the public API and serialized formats unchanged. The same cryptographic constructors are still receiving an OS-backed CSPRNG; the change removes the `rand` facade where only `RngCore`/`CryptoRng` are needed.

The PR also includes an `Unreleased` changelog entry as requested by the contribution guide.

## Why this shape

The affected APIs need an RNG implementing `rand_core` traits. Depending directly on `rand_core` and using `OsRng` keeps that requirement explicit and avoids carrying the higher-level `rand` crate for these production call sites.

I kept the existing direct `getrandom` dependency untouched because it is still used by the `js` feature path.

## Tradeoffs

The alternative would be upgrading to a newer `rand` line and continuing to use `thread_rng`. That would preserve the facade dependency and still be more than these call sites need. Direct `OsRng` is narrower and better matches the crypto boundary.

## Verification

- `RUSTUP_HOME=/Volumes/wd_black/rustup-home CARGO_HOME=/Volumes/wd_black/cargo-home rustup run nightly cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets-upstream/vodozemac RUSTUP_HOME=/Volumes/wd_black/rustup-home CARGO_HOME=/Volumes/wd_black/cargo-home rustup run nightly cargo clippy --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets-upstream/vodozemac RUSTUP_HOME=/Volumes/wd_black/rustup-home CARGO_HOME=/Volumes/wd_black/cargo-home rustup run nightly cargo clippy --all-targets --no-default-features -- -D warnings`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets-upstream/vodozemac cargo test --all-features`
- `CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets-upstream/vodozemac cargo test --no-default-features`
- `PATH=/Volumes/wd_black/cargo-home/bin:$PATH CARGO_HOME=/Volumes/wd_black/cargo-home CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets-upstream/vodozemac cargo hack check --feature-powerset --all-targets`
- `PATH=/Volumes/wd_black/cargo-home/bin:$PATH CARGO_HOME=/Volumes/wd_black/cargo-home CARGO_TARGET_DIR=/Volumes/wd_black/cargo-targets-upstream/vodozemac cargo nextest run --all-features`

Note: I installed `cmake` locally because the all-features path builds `olm-sys`.

Signed-off-by: Shea Winkler <shea.winkler@algotrade-ai.com>
