### PR TITLE
deps: disable default features on x25519-dalek (consistency; drops ~40 KB of basepoint tables from downstreams)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to this project will be documented in this file.
 
 - Add a new `olm::Session` constructor which allows the 3DH step to be skipped.
   ([#341](https://github.com/matrix-org/vodozemac/pull/341))
+- Add a new default-enabled `precomputed-tables` feature flag which controls
+  curve25519-dalek's precomputed basepoint tables. Size-sensitive builds can
+  now disable the default features to drop roughly 40 KB of lookup tables from
+  the final binary, at the cost of slower key generation and Ed25519 signing.
+  ([#369](https://github.com/matrix-org/vodozemac/pull/369))
 
 ## [0.10.0] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Add a new `olm::Session` constructor which allows the 3DH step to be skipped.
-  ([#341](https://github.com/matrix-org/vodozemac/pull/341))
 - Add a new default-enabled `precomputed-tables` feature flag which controls
   curve25519-dalek's precomputed basepoint tables. Size-sensitive builds can
   now disable the default features to drop roughly 40 KB of lookup tables from
   the final binary, at the cost of slower key generation and Ed25519 signing.
   ([#369](https://github.com/matrix-org/vodozemac/pull/369))
+- Add a new `olm::Session` constructor which allows the 3DH step to be skipped.
+  ([#341](https://github.com/matrix-org/vodozemac/pull/341))
 
 ## [0.10.0] - 2026-04-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,13 @@ unwrap_used = "deny"
 mem_forget = "deny"
 
 [features]
-default = ["libolm-compat"]
+default = ["libolm-compat", "precomputed-tables"]
 js = ["getrandom/js"]
 libolm-compat = []
+# Enables curve25519-dalek's precomputed basepoint tables, speeding up
+# fixed-base scalar multiplication (key generation and Ed25519 signing) at the
+# cost of embedding ~40 KB of lookup tables in the final binary.
+precomputed-tables = ["curve25519-dalek/precomputed-tables"]
 insecure-pk-encryption = ["libolm-compat"]
 experimental-session-config = []
 # The low-level-api feature exposes extra APIs that are only useful in advanced

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ serde_json = "1.0.140"
 sha2 = "0.10.9"
 subtle = "2.6.1"
 thiserror = "2.0.18"
-x25519-dalek = { version = "2.0.1", features = ["serde", "reusable_secrets", "static_secrets", "zeroize"] }
+x25519-dalek = { version = "2.0.1", default-features = false, features = ["alloc", "serde", "reusable_secrets", "static_secrets", "zeroize"] }
 zeroize = "1.8.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,22 @@
 //! Extreme care must be taken when using such APIs, as incorrect usage can lead
 //! to broken sessions.
 //!
+//! ## Precomputed tables
+//!
+//! Feature: `precomputed-tables` (default: on)
+//!
+//! Enables curve25519-dalek's precomputed basepoint tables, which speed up
+//! fixed-base scalar multiplication — key generation and Ed25519 signing — at
+//! the cost of embedding roughly 40 KB of lookup tables in the final binary.
+//! Variable-base operations, such as the X25519 Diffie-Hellman used by the
+//! Double Ratchet, are unaffected.
+//!
+//! Size-sensitive builds can drop the tables by disabling default features:
+//!
+//! ```toml
+//! vodozemac = { version = "0.10.0", default-features = false, features = ["libolm-compat"] }
+//! ```
+//!
 //! # Pickling
 //!
 //! vodozemac supports serializing its entire internal state into a form


### PR DESCRIPTION
## Summary

`vodozemac` already declares `default-features = false` on **`ed25519-dalek`** and **`curve25519-dalek`**, signaling it does not intend to require curve25519-dalek's `precomputed-tables` feature. But `x25519-dalek` is declared *with* its defaults, and x25519-dalek's default set includes `precomputed-tables` (`default = ["alloc", "precomputed-tables", "zeroize"]`).

Because Cargo unifies features across the whole dependency graph, this single declaration silently re-enables `curve25519-dalek/precomputed-tables` for the **entire** build — negating the `default-features = false` on the other two dalek crates, and forcing the large precomputed basepoint lookup tables into every downstream binary, with no way for a downstream to opt out (Cargo has no mechanism to disable a transitively-requested feature).

## Change

```diff
-x25519-dalek = { version = "2.0.1", features = ["serde", "reusable_secrets", "static_secrets", "zeroize"] }
+x25519-dalek = { version = "2.0.1", default-features = false, features = ["alloc", "serde", "reusable_secrets", "static_secrets", "zeroize"] }
```

`alloc` is re-added explicitly so the **only** net change to the resolved feature set is the removal of `precomputed-tables`.

## Affected symbols

| Symbol | Size |
|---|---|
| `curve25519_dalek::…::ED25519_BASEPOINT_TABLE_INNER_DOC_HIDDEN` | ~30 KB |
| `curve25519_dalek::backend::vector::avx2::…::BASEPOINT_ODD_LOOKUP_TABLE` | ~10 KB |

## Measured impact

Measured on a downstream `cdylib` that links vodozemac (release: `lto = true`, `opt-level = 3`, `codegen-units = 1`, stripped):

```
before: 1,002,496 bytes
after:    965,240 bytes   (−37,256 bytes, −3.7%)
```

The downstream test suite (Olm session round-trips, pickling, KATs) passes unchanged — `precomputed-tables` is a pure size/speed trade with no behavioral effect.

## Tradeoff

Disabling `precomputed-tables` removes the fixed-base scalar-multiplication speedup, which affects **key generation** (`PublicKey::from(&StaticSecret)`) and Ed25519 **signing**. It does **not** affect x25519 ECDH (variable-base — the hot Double Ratchet operation is unchanged). These fixed-base operations are not hot paths for typical messaging workloads, and this aligns vodozemac's actual behavior with what its `ed25519-dalek`/`curve25519-dalek` declarations already intend.

If you'd prefer to keep the speedup as the default, an alternative is to expose it as an opt-in feature (e.g. `precomputed-tables = ["curve25519-dalek/precomputed-tables"]`) so size-sensitive downstreams can leave it off. Happy to adjust the PR in whichever direction you prefer.
