### PR TITLE
Add additive `*_with_rng` entropy-injection variants to the Olm API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
+- Add additive `*_with_rng` variants to every `olm` key-generation entry point
+  (`Account::new`, `Account::generate_one_time_keys`,
+  `Account::generate_fallback_key`, `Account::create_outbound_session` and
+  `Session::encrypt`, plus the `Curve25519SecretKey`/`Ed25519Keypair`/
+  `Ed25519SecretKey` constructors). These accept a caller-supplied
+  `impl CryptoRng` so randomness can be injected for deterministic testing,
+  reproducible builds and custom/hardware entropy sources. The existing
+  `OsRng`-backed methods are unchanged.
 - Add a new default-enabled `precomputed-tables` feature flag which controls
   curve25519-dalek's precomputed basepoint tables. Size-sensitive builds can
   now disable the default features to drop roughly 40 KB of lookup tables from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
   `impl CryptoRng` so randomness can be injected for deterministic testing,
   reproducible builds and custom/hardware entropy sources. The existing
   `OsRng`-backed methods are unchanged.
+  ([#379](https://github.com/matrix-org/vodozemac/pull/379))
 - Add a new default-enabled `precomputed-tables` feature flag which controls
   curve25519-dalek's precomputed basepoint tables. Size-sensitive builds can
   now disable the default features to drop roughly 40 KB of lookup tables from

--- a/src/olm/account/fallback_keys.rs
+++ b/src/olm/account/fallback_keys.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rand::CryptoRng;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -29,6 +30,12 @@ pub(super) struct FallbackKey {
 impl FallbackKey {
     fn new(key_id: KeyId) -> Self {
         let key = Curve25519SecretKey::new();
+
+        Self { key_id, key, published: false }
+    }
+
+    fn new_with_rng<R: CryptoRng>(key_id: KeyId, rng: &mut R) -> Self {
+        let key = Curve25519SecretKey::new_with_rng(rng);
 
         Self { key_id, key, published: false }
     }
@@ -80,6 +87,21 @@ impl FallbackKeys {
 
         self.previous_fallback_key = self.fallback_key.take();
         self.fallback_key = Some(FallbackKey::new(key_id));
+
+        ret
+    }
+
+    pub fn generate_fallback_key_with_rng<R: CryptoRng>(
+        &mut self,
+        rng: &mut R,
+    ) -> Option<Curve25519PublicKey> {
+        let key_id = KeyId(self.key_id);
+        self.key_id += 1;
+
+        let ret = self.previous_fallback_key.take().map(|f| f.public_key());
+
+        self.previous_fallback_key = self.fallback_key.take();
+        self.fallback_key = Some(FallbackKey::new_with_rng(key_id, rng));
 
         ret
     }

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -22,6 +22,7 @@ use chacha20poly1305::{
     aead::{Aead, KeyInit},
 };
 use cipher::common::Generate;
+use rand::CryptoRng;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use zeroize::Zeroize;
@@ -150,6 +151,28 @@ impl Account {
         }
     }
 
+    /// Create a new [`Account`] with new random identity keys, drawing entropy
+    /// from the provided random number generator.
+    ///
+    /// This behaves exactly like [`Account::new`] but sources its randomness
+    /// from the caller-supplied `rng` instead of the thread-local generator. It
+    /// enables deterministic testing, reproducible builds, and custom/hardware
+    /// entropy sources.
+    ///
+    /// **Warning**: the security of the account's identity keys rests entirely
+    /// on the quality of `rng`. Supplying a low-entropy, predictable, or reused
+    /// generator yields predictable identity keys and breaks the security of any
+    /// session built from this account. Pass a cryptographically secure
+    /// generator seeded with sufficient entropy.
+    pub fn new_with_rng<R: CryptoRng>(rng: &mut R) -> Self {
+        Self {
+            signing_key: Ed25519Keypair::new_with_rng(rng),
+            diffie_hellman_key: Curve25519Keypair::new_with_rng(rng),
+            one_time_keys: OneTimeKeys::new(),
+            fallback_keys: FallbackKeys::new(),
+        }
+    }
+
     /// Get the [`IdentityKeys`] of this Account
     pub const fn identity_keys(&self) -> IdentityKeys {
         IdentityKeys { ed25519: self.ed25519_key(), curve25519: self.curve25519_key() }
@@ -214,6 +237,47 @@ impl Account {
         };
 
         Ok(Session::new(session_config, shared_secret, session_keys))
+    }
+
+    /// Create a [`Session`] with the given identity key and one-time key,
+    /// drawing entropy from the provided random number generator.
+    ///
+    /// This behaves exactly like [`Account::create_outbound_session`] but
+    /// sources its randomness from the caller-supplied `rng` instead of the
+    /// thread-local generator. It enables deterministic testing, reproducible
+    /// builds, and custom/hardware entropy sources.
+    ///
+    /// **Warning**: the security of the resulting session rests entirely on the
+    /// quality of `rng`; the ephemeral base key and initial ratchet key it mints
+    /// must come from fresh, high-quality randomness. Supplying a low-entropy,
+    /// predictable, or reused generator breaks forward secrecy and
+    /// authentication. Pass a cryptographically secure generator seeded with
+    /// sufficient entropy.
+    pub fn create_outbound_session_with_rng<R: CryptoRng>(
+        &self,
+        session_config: SessionConfig,
+        identity_key: Curve25519PublicKey,
+        one_time_key: Curve25519PublicKey,
+        rng: &mut R,
+    ) -> Result<Session, SessionCreationError> {
+        let base_key = Curve25519SecretKey::new_with_rng(rng);
+        let public_base_key = Curve25519PublicKey::from(&base_key);
+
+        let shared_secret = Shared3DHSecret::new(
+            self.diffie_hellman_key.secret_key(),
+            &base_key,
+            &identity_key,
+            &one_time_key,
+        )
+        .ok_or(SessionCreationError::NonContributoryKey)?;
+
+        let session_keys = SessionKeys {
+            identity_key: self.curve25519_key(),
+            base_key: public_base_key,
+            one_time_key,
+        };
+
+        Ok(Session::new_with_rng(session_config, shared_secret, session_keys, rng))
     }
 
     /// Try to find a [`Curve25519SecretKey`] that forms a pair with the given
@@ -339,6 +403,26 @@ impl Account {
         self.one_time_keys.generate(count)
     }
 
+    /// Generates the supplied number of one time keys, drawing entropy from the
+    /// provided random number generator.
+    ///
+    /// This behaves exactly like [`Account::generate_one_time_keys`] but sources
+    /// its randomness from the caller-supplied `rng` instead of the thread-local
+    /// generator. It enables deterministic testing, reproducible builds, and
+    /// custom/hardware entropy sources.
+    ///
+    /// **Warning**: the security of the generated one-time keys rests entirely
+    /// on the quality of `rng`. Supplying a low-entropy, predictable, or reused
+    /// generator yields predictable one-time keys. Pass a cryptographically
+    /// secure generator seeded with sufficient entropy.
+    pub fn generate_one_time_keys_with_rng<R: CryptoRng>(
+        &mut self,
+        count: usize,
+        rng: &mut R,
+    ) -> OneTimeKeyGenerationResult {
+        self.one_time_keys.generate_with_rng(count, rng)
+    }
+
     /// Get the number of one-time keys we have stored locally.
     ///
     /// This will be equal or greater to the number of one-time keys we have
@@ -371,6 +455,25 @@ impl Account {
     /// is called. This return value is mostly useful for logging purposes.
     pub fn generate_fallback_key(&mut self) -> Option<Curve25519PublicKey> {
         self.fallback_keys.generate_fallback_key()
+    }
+
+    /// Generate a single new fallback key, drawing entropy from the provided
+    /// random number generator.
+    ///
+    /// This behaves exactly like [`Account::generate_fallback_key`] but sources
+    /// its randomness from the caller-supplied `rng` instead of the thread-local
+    /// generator. It enables deterministic testing, reproducible builds, and
+    /// custom/hardware entropy sources.
+    ///
+    /// **Warning**: the security of the generated fallback key rests entirely on
+    /// the quality of `rng`. Supplying a low-entropy, predictable, or reused
+    /// generator yields a predictable fallback key. Pass a cryptographically
+    /// secure generator seeded with sufficient entropy.
+    pub fn generate_fallback_key_with_rng<R: CryptoRng>(
+        &mut self,
+        rng: &mut R,
+    ) -> Option<Curve25519PublicKey> {
+        self.fallback_keys.generate_fallback_key_with_rng(rng)
     }
 
     /// Get the currently unpublished fallback key.

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -161,8 +161,8 @@ impl Account {
     ///
     /// **Warning**: the security of the account's identity keys rests entirely
     /// on the quality of `rng`. Supplying a low-entropy, predictable, or reused
-    /// generator yields predictable identity keys and breaks the security of any
-    /// session built from this account. Pass a cryptographically secure
+    /// generator yields predictable identity keys and breaks the security of
+    /// any session built from this account. Pass a cryptographically secure
     /// generator seeded with sufficient entropy.
     pub fn new_with_rng<R: CryptoRng>(rng: &mut R) -> Self {
         Self {
@@ -248,11 +248,11 @@ impl Account {
     /// builds, and custom/hardware entropy sources.
     ///
     /// **Warning**: the security of the resulting session rests entirely on the
-    /// quality of `rng`; the ephemeral base key and initial ratchet key it mints
-    /// must come from fresh, high-quality randomness. Supplying a low-entropy,
-    /// predictable, or reused generator breaks forward secrecy and
-    /// authentication. Pass a cryptographically secure generator seeded with
-    /// sufficient entropy.
+    /// quality of `rng`; the ephemeral base key and initial ratchet key it
+    /// mints must come from fresh, high-quality randomness. Supplying a
+    /// low-entropy, predictable, or reused generator breaks forward secrecy
+    /// and authentication. Pass a cryptographically secure generator seeded
+    /// with sufficient entropy.
     pub fn create_outbound_session_with_rng<R: CryptoRng>(
         &self,
         session_config: SessionConfig,
@@ -406,10 +406,10 @@ impl Account {
     /// Generates the supplied number of one time keys, drawing entropy from the
     /// provided random number generator.
     ///
-    /// This behaves exactly like [`Account::generate_one_time_keys`] but sources
-    /// its randomness from the caller-supplied `rng` instead of the thread-local
-    /// generator. It enables deterministic testing, reproducible builds, and
-    /// custom/hardware entropy sources.
+    /// This behaves exactly like [`Account::generate_one_time_keys`] but
+    /// sources its randomness from the caller-supplied `rng` instead of the
+    /// thread-local generator. It enables deterministic testing,
+    /// reproducible builds, and custom/hardware entropy sources.
     ///
     /// **Warning**: the security of the generated one-time keys rests entirely
     /// on the quality of `rng`. Supplying a low-entropy, predictable, or reused
@@ -461,14 +461,14 @@ impl Account {
     /// random number generator.
     ///
     /// This behaves exactly like [`Account::generate_fallback_key`] but sources
-    /// its randomness from the caller-supplied `rng` instead of the thread-local
-    /// generator. It enables deterministic testing, reproducible builds, and
-    /// custom/hardware entropy sources.
+    /// its randomness from the caller-supplied `rng` instead of the
+    /// thread-local generator. It enables deterministic testing,
+    /// reproducible builds, and custom/hardware entropy sources.
     ///
-    /// **Warning**: the security of the generated fallback key rests entirely on
-    /// the quality of `rng`. Supplying a low-entropy, predictable, or reused
-    /// generator yields a predictable fallback key. Pass a cryptographically
-    /// secure generator seeded with sufficient entropy.
+    /// **Warning**: the security of the generated fallback key rests entirely
+    /// on the quality of `rng`. Supplying a low-entropy, predictable, or
+    /// reused generator yields a predictable fallback key. Pass a
+    /// cryptographically secure generator seeded with sufficient entropy.
     pub fn generate_fallback_key_with_rng<R: CryptoRng>(
         &mut self,
         rng: &mut R,

--- a/src/olm/account/one_time_keys.rs
+++ b/src/olm/account/one_time_keys.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
+use rand::CryptoRng;
 use serde::{Deserialize, Serialize};
 
 use super::PUBLIC_MAX_ONE_TIME_KEYS;
@@ -118,6 +119,15 @@ impl OneTimeKeys {
         self.insert_secret_key(key_id, key, false)
     }
 
+    fn generate_one_time_key_with_rng<R: CryptoRng>(
+        &mut self,
+        rng: &mut R,
+    ) -> (Curve25519PublicKey, Option<Curve25519PublicKey>) {
+        let key_id = KeyId(self.next_key_id);
+        let key = Curve25519SecretKey::new_with_rng(rng);
+        self.insert_secret_key(key_id, key, false)
+    }
+
     pub(crate) const fn secret_keys(&self) -> &BTreeMap<KeyId, Curve25519SecretKey> {
         &self.private_keys
     }
@@ -133,6 +143,28 @@ impl OneTimeKeys {
 
         for _ in 0..count {
             let (created, removed) = self.generate_one_time_key();
+
+            created_keys.push(created);
+            if let Some(removed) = removed {
+                removed_keys.push(removed);
+            }
+
+            self.next_key_id = self.next_key_id.wrapping_add(1);
+        }
+
+        OneTimeKeyGenerationResult { created: created_keys, removed: removed_keys }
+    }
+
+    pub fn generate_with_rng<R: CryptoRng>(
+        &mut self,
+        count: usize,
+        rng: &mut R,
+    ) -> OneTimeKeyGenerationResult {
+        let mut removed_keys = Vec::new();
+        let mut created_keys = Vec::new();
+
+        for _ in 0..count {
+            let (created, removed) = self.generate_one_time_key_with_rng(rng);
 
             created_keys.push(created);
             if let Some(removed) = removed {

--- a/src/olm/session/double_ratchet.rs
+++ b/src/olm/session/double_ratchet.rs
@@ -14,6 +14,7 @@
 
 use std::fmt::{Debug, Formatter};
 
+use rand::CryptoRng;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "low-level-api")]
@@ -63,14 +64,54 @@ impl DoubleRatchet {
         }
     }
 
+    pub fn next_message_key_with_rng<R: CryptoRng>(
+        &mut self,
+        rng: &mut R,
+    ) -> Option<MessageKey> {
+        match &mut self.inner {
+            DoubleRatchetState::Inactive(ratchet) => {
+                let mut ratchet = ratchet.activate_with_rng(rng)?;
+
+                let message_key = ratchet.next_message_key();
+                self.inner = DoubleRatchetState::Active(ratchet);
+
+                Some(message_key)
+            }
+            DoubleRatchetState::Active(ratchet) => Some(ratchet.next_message_key()),
+        }
+    }
+
     #[cfg(feature = "experimental-session-config")]
     pub fn encrypt(&mut self, plaintext: &[u8]) -> Result<Message, EncryptionError> {
         Ok(self.next_message_key().ok_or(EncryptionError::NonContributoryKey)?.encrypt(plaintext))
     }
 
+    #[cfg(feature = "experimental-session-config")]
+    pub fn encrypt_with_rng<R: CryptoRng>(
+        &mut self,
+        plaintext: &[u8],
+        rng: &mut R,
+    ) -> Result<Message, EncryptionError> {
+        Ok(self
+            .next_message_key_with_rng(rng)
+            .ok_or(EncryptionError::NonContributoryKey)?
+            .encrypt(plaintext))
+    }
+
     pub fn encrypt_truncated_mac(&mut self, plaintext: &[u8]) -> Result<Message, EncryptionError> {
         Ok(self
             .next_message_key()
+            .ok_or(EncryptionError::NonContributoryKey)?
+            .encrypt_truncated_mac(plaintext))
+    }
+
+    pub fn encrypt_truncated_mac_with_rng<R: CryptoRng>(
+        &mut self,
+        plaintext: &[u8],
+        rng: &mut R,
+    ) -> Result<Message, EncryptionError> {
+        Ok(self
+            .next_message_key_with_rng(rng)
             .ok_or(EncryptionError::NonContributoryKey)?
             .encrypt_truncated_mac(plaintext))
     }
@@ -87,6 +128,25 @@ impl DoubleRatchet {
             parent_ratchet_key: None, // First chain in a session lacks parent ratchet key
             ratchet_count: RatchetCount::new(),
             active_ratchet: Ratchet::new(root_key),
+            symmetric_key_ratchet: chain_key,
+        };
+
+        Self { inner: ratchet.into() }
+    }
+
+    pub fn active_with_rng<R: CryptoRng>(
+        shared_secret: Shared3DHSecret,
+        rng: &mut R,
+    ) -> Self {
+        let (root_key, chain_key) = shared_secret.expand();
+
+        let root_key = RootKey::new(root_key);
+        let chain_key = ChainKey::new(chain_key);
+
+        let ratchet = ActiveDoubleRatchet {
+            parent_ratchet_key: None, // First chain in a session lacks parent ratchet key
+            ratchet_count: RatchetCount::new(),
+            active_ratchet: Ratchet::new_with_rng(root_key, rng),
             symmetric_key_ratchet: chain_key,
         };
 
@@ -241,6 +301,22 @@ struct InactiveDoubleRatchet {
 impl InactiveDoubleRatchet {
     fn activate(&self) -> Option<ActiveDoubleRatchet> {
         let (root_key, chain_key, ratchet_key) = self.root_key.advance(&self.ratchet_key)?;
+        let active_ratchet = Ratchet::new_with_ratchet_key(root_key, ratchet_key);
+
+        Some(ActiveDoubleRatchet {
+            parent_ratchet_key: Some(self.ratchet_key),
+            ratchet_count: self.ratchet_count.advance(),
+            active_ratchet,
+            symmetric_key_ratchet: chain_key,
+        })
+    }
+
+    fn activate_with_rng<R: CryptoRng>(
+        &self,
+        rng: &mut R,
+    ) -> Option<ActiveDoubleRatchet> {
+        let (root_key, chain_key, ratchet_key) =
+            self.root_key.advance_with_rng(&self.ratchet_key, rng)?;
         let active_ratchet = Ratchet::new_with_ratchet_key(root_key, ratchet_key);
 
         Some(ActiveDoubleRatchet {

--- a/src/olm/session/double_ratchet.rs
+++ b/src/olm/session/double_ratchet.rs
@@ -64,10 +64,7 @@ impl DoubleRatchet {
         }
     }
 
-    pub fn next_message_key_with_rng<R: CryptoRng>(
-        &mut self,
-        rng: &mut R,
-    ) -> Option<MessageKey> {
+    pub fn next_message_key_with_rng<R: CryptoRng>(&mut self, rng: &mut R) -> Option<MessageKey> {
         match &mut self.inner {
             DoubleRatchetState::Inactive(ratchet) => {
                 let mut ratchet = ratchet.activate_with_rng(rng)?;
@@ -134,10 +131,7 @@ impl DoubleRatchet {
         Self { inner: ratchet.into() }
     }
 
-    pub fn active_with_rng<R: CryptoRng>(
-        shared_secret: Shared3DHSecret,
-        rng: &mut R,
-    ) -> Self {
+    pub fn active_with_rng<R: CryptoRng>(shared_secret: Shared3DHSecret, rng: &mut R) -> Self {
         let (root_key, chain_key) = shared_secret.expand();
 
         let root_key = RootKey::new(root_key);
@@ -311,10 +305,7 @@ impl InactiveDoubleRatchet {
         })
     }
 
-    fn activate_with_rng<R: CryptoRng>(
-        &self,
-        rng: &mut R,
-    ) -> Option<ActiveDoubleRatchet> {
+    fn activate_with_rng<R: CryptoRng>(&self, rng: &mut R) -> Option<ActiveDoubleRatchet> {
         let (root_key, chain_key, ratchet_key) =
             self.root_key.advance_with_rng(&self.ratchet_key, rng)?;
         let active_ratchet = Ratchet::new_with_ratchet_key(root_key, ratchet_key);

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -423,17 +423,18 @@ impl Session {
     /// This behaves exactly like [`Session::encrypt`] but sources its
     /// randomness from the caller-supplied `rng` instead of the thread-local
     /// generator. Randomness is consumed **only** when the ratchet advances the
-    /// Diffie-Hellman step (i.e. the first message sent after receiving a reply,
-    /// which mints a fresh ratchet key); messages that merely advance the
-    /// symmetric chain draw nothing from `rng`. This enables deterministic
-    /// testing, reproducible builds, and custom/hardware entropy sources.
+    /// Diffie-Hellman step (i.e. the first message sent after receiving a
+    /// reply, which mints a fresh ratchet key); messages that merely
+    /// advance the symmetric chain draw nothing from `rng`. This enables
+    /// deterministic testing, reproducible builds, and custom/hardware
+    /// entropy sources.
     ///
     /// **Warning**: the forward secrecy and post-compromise security of the
     /// session depend on each genuinely-new ratchet step drawing *fresh*,
     /// high-quality randomness. Supplying a low-entropy, predictable, or reused
     /// generator across two distinct ratchet advances collapses the ephemeral
-    /// ratchet keys and breaks these guarantees. Pass a cryptographically secure
-    /// generator seeded with sufficient entropy.
+    /// ratchet keys and breaks these guarantees. Pass a cryptographically
+    /// secure generator seeded with sufficient entropy.
     pub fn encrypt_with_rng<R: CryptoRng>(
         &mut self,
         plaintext: impl AsRef<[u8]>,

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -27,6 +27,7 @@ use arrayvec::ArrayVec;
 use chain_key::RemoteChainKey;
 use double_ratchet::DoubleRatchet;
 use hmac::digest::MacError;
+use rand::CryptoRng;
 use ratchet::RemoteRatchetKey;
 use receiver_chain::ReceiverChain;
 use root_key::RemoteRootKey;
@@ -336,6 +337,22 @@ impl Session {
         }
     }
 
+    pub(super) fn new_with_rng<R: CryptoRng>(
+        config: SessionConfig,
+        shared_secret: Shared3DHSecret,
+        session_keys: SessionKeys,
+        rng: &mut R,
+    ) -> Self {
+        let local_ratchet = DoubleRatchet::active_with_rng(shared_secret, rng);
+
+        Self {
+            session_keys,
+            sending_ratchet: local_ratchet,
+            receiving_chains: Default::default(),
+            config,
+        }
+    }
+
     pub(super) fn new_remote(
         config: SessionConfig,
         shared_secret: RemoteShared3DHSecret,
@@ -389,6 +406,45 @@ impl Session {
             Version::V1 => self.sending_ratchet.encrypt_truncated_mac(plaintext.as_ref()),
             #[cfg(feature = "experimental-session-config")]
             Version::V2 => self.sending_ratchet.encrypt(plaintext.as_ref()),
+        }?;
+
+        if self.has_received_message() {
+            Ok(OlmMessage::Normal(message))
+        } else {
+            let message = PreKeyMessage::new(self.session_keys, message);
+
+            Ok(OlmMessage::PreKey(message))
+        }
+    }
+
+    /// Encrypt the `plaintext` and construct an [`OlmMessage`], drawing any
+    /// required entropy from the provided random number generator.
+    ///
+    /// This behaves exactly like [`Session::encrypt`] but sources its
+    /// randomness from the caller-supplied `rng` instead of the thread-local
+    /// generator. Randomness is consumed **only** when the ratchet advances the
+    /// Diffie-Hellman step (i.e. the first message sent after receiving a reply,
+    /// which mints a fresh ratchet key); messages that merely advance the
+    /// symmetric chain draw nothing from `rng`. This enables deterministic
+    /// testing, reproducible builds, and custom/hardware entropy sources.
+    ///
+    /// **Warning**: the forward secrecy and post-compromise security of the
+    /// session depend on each genuinely-new ratchet step drawing *fresh*,
+    /// high-quality randomness. Supplying a low-entropy, predictable, or reused
+    /// generator across two distinct ratchet advances collapses the ephemeral
+    /// ratchet keys and breaks these guarantees. Pass a cryptographically secure
+    /// generator seeded with sufficient entropy.
+    pub fn encrypt_with_rng<R: CryptoRng>(
+        &mut self,
+        plaintext: impl AsRef<[u8]>,
+        rng: &mut R,
+    ) -> Result<OlmMessage, EncryptionError> {
+        let message = match self.config.version {
+            Version::V1 => {
+                self.sending_ratchet.encrypt_truncated_mac_with_rng(plaintext.as_ref(), rng)
+            }
+            #[cfg(feature = "experimental-session-config")]
+            Version::V2 => self.sending_ratchet.encrypt_with_rng(plaintext.as_ref(), rng),
         }?;
 
         if self.has_received_message() {

--- a/src/olm/session/ratchet.rs
+++ b/src/olm/session/ratchet.rs
@@ -15,6 +15,7 @@
 use std::fmt::Debug;
 
 use matrix_pickle::Decode;
+use rand::CryptoRng;
 use serde::{Deserialize, Serialize};
 use x25519_dalek::SharedSecret;
 
@@ -61,6 +62,10 @@ impl Debug for RemoteRatchetKey {
 impl RatchetKey {
     pub fn new() -> Self {
         Self(Curve25519SecretKey::new())
+    }
+
+    pub fn new_with_rng<R: CryptoRng>(rng: &mut R) -> Self {
+        Self(Curve25519SecretKey::new_with_rng(rng))
     }
 
     pub fn diffie_hellman(&self, other: &RemoteRatchetKey) -> Option<SharedSecret> {
@@ -125,6 +130,12 @@ pub(super) struct Ratchet {
 impl Ratchet {
     pub fn new(root_key: RootKey) -> Self {
         let ratchet_key = RatchetKey::new();
+
+        Self { root_key, ratchet_key }
+    }
+
+    pub fn new_with_rng<R: CryptoRng>(root_key: RootKey, rng: &mut R) -> Self {
+        let ratchet_key = RatchetKey::new_with_rng(rng);
 
         Self { root_key, ratchet_key }
     }

--- a/src/olm/session/root_key.rs
+++ b/src/olm/session/root_key.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use hkdf::Hkdf;
+use rand::CryptoRng;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -75,6 +76,26 @@ impl RemoteRootKey {
         remote_ratchet_key: &RemoteRatchetKey,
     ) -> Option<(RootKey, ChainKey, RatchetKey)> {
         let ratchet_key = RatchetKey::new();
+        let output = kdf(&self.key, &ratchet_key, remote_ratchet_key)?;
+
+        let mut chain_key = Box::new([0u8; 32]);
+        let mut root_key = Box::new([0u8; 32]);
+
+        chain_key.copy_from_slice(&output[32..]);
+        root_key.copy_from_slice(&output[..32]);
+
+        let chain_key = ChainKey::new(chain_key);
+        let root_key = RootKey::new(root_key);
+
+        Some((root_key, chain_key, ratchet_key))
+    }
+
+    pub(super) fn advance_with_rng<R: CryptoRng>(
+        &self,
+        remote_ratchet_key: &RemoteRatchetKey,
+        rng: &mut R,
+    ) -> Option<(RootKey, ChainKey, RatchetKey)> {
+        let ratchet_key = RatchetKey::new_with_rng(rng);
         let output = kdf(&self.key, &ratchet_key, remote_ratchet_key)?;
 
         let mut chain_key = Box::new([0u8; 32]);

--- a/src/types/curve25519.rs
+++ b/src/types/curve25519.rs
@@ -16,7 +16,7 @@ use std::fmt::Display;
 
 use base64::decoded_len_estimate;
 use matrix_pickle::{Decode, DecodeError};
-use rand::rng;
+use rand::{CryptoRng, rng};
 use serde::{Deserialize, Serialize};
 use x25519_dalek::{EphemeralSecret, PublicKey, ReusableSecret, SharedSecret, StaticSecret};
 use zeroize::Zeroize;
@@ -35,6 +35,23 @@ impl Curve25519SecretKey {
         let mut rng = rng();
 
         Self(Box::new(StaticSecret::random_from_rng(&mut rng)))
+    }
+
+    /// Generate a new, random, `Curve25519SecretKey`, drawing entropy from the
+    /// provided random number generator.
+    ///
+    /// This behaves exactly like [`Curve25519SecretKey::new`] but sources its
+    /// randomness from the caller-supplied `rng` instead of the thread-local
+    /// generator. It is useful for deterministic testing, reproducible builds,
+    /// and integrating hardware or otherwise custom entropy sources.
+    ///
+    /// **Warning**: the security of the generated key rests entirely on the
+    /// quality of `rng`. Supplying a low-entropy, predictable, or reused
+    /// generator yields predictable or repeated secret keys and breaks the
+    /// security of any protocol built on top of them. Pass a cryptographically
+    /// secure generator seeded with sufficient entropy.
+    pub fn new_with_rng<R: CryptoRng>(rng: &mut R) -> Self {
+        Self(Box::new(StaticSecret::random_from_rng(rng)))
     }
 
     /// Create a `Curve25519SecretKey` from the given slice of bytes.
@@ -87,6 +104,13 @@ pub(crate) struct Curve25519Keypair {
 impl Curve25519Keypair {
     pub fn new() -> Self {
         let secret_key = Curve25519SecretKey::new();
+        let public_key = Curve25519PublicKey::from(&secret_key);
+
+        Self { secret_key, public_key }
+    }
+
+    pub fn new_with_rng<R: CryptoRng>(rng: &mut R) -> Self {
+        let secret_key = Curve25519SecretKey::new_with_rng(rng);
         let public_key = Curve25519PublicKey::from(&secret_key);
 
         Self { secret_key, public_key }

--- a/src/types/ed25519.rs
+++ b/src/types/ed25519.rs
@@ -20,7 +20,7 @@ use curve25519_dalek::EdwardsPoint;
 use ed25519_dalek::{
     PUBLIC_KEY_LENGTH, SIGNATURE_LENGTH, Signature, Signer, SigningKey, VerifyingKey,
 };
-use rand::rng;
+use rand::{CryptoRng, rng};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_bytes::{ByteBuf as SerdeByteBuf, Bytes as SerdeBytes};
 use sha2::Sha512;
@@ -136,6 +136,27 @@ impl Ed25519Keypair {
         }
     }
 
+    /// Create a new, random, `Ed25519Keypair`, drawing entropy from the
+    /// provided random number generator.
+    ///
+    /// This behaves exactly like [`Ed25519Keypair::new`] but sources its
+    /// randomness from the caller-supplied `rng` instead of the thread-local
+    /// generator (see [`Ed25519Keypair::new`]). It enables deterministic
+    /// testing, reproducible builds, and custom/hardware entropy sources.
+    ///
+    /// **Warning**: the security of the generated keypair rests entirely on the
+    /// quality of `rng`; a low-entropy, predictable, or reused generator yields
+    /// predictable or repeated keys. Pass a cryptographically secure generator
+    /// seeded with sufficient entropy.
+    pub fn new_with_rng<R: CryptoRng>(rng: &mut R) -> Self {
+        let signing_key = SigningKey::generate(rng);
+
+        Self {
+            public_key: Ed25519PublicKey(signing_key.verifying_key()),
+            secret_key: signing_key.into(),
+        }
+    }
+
     pub(crate) fn from_unexpanded_key(secret_key: &[u8; 32]) -> Result<Self, crate::KeyError> {
         let secret_key = SigningKey::from_bytes(secret_key);
         let public_key = secret_key.verifying_key();
@@ -211,6 +232,25 @@ impl Ed25519SecretKey {
     pub fn new() -> Self {
         let mut rng = rng();
         let signing_key = SigningKey::generate(&mut rng);
+        let key = Box::new(signing_key);
+
+        Self(key)
+    }
+
+    /// Create a new random `Ed25519SecretKey`, drawing entropy from the provided
+    /// random number generator.
+    ///
+    /// This behaves exactly like [`Ed25519SecretKey::new`] but sources its
+    /// randomness from the caller-supplied `rng` instead of the thread-local
+    /// generator. It enables deterministic testing, reproducible builds, and
+    /// custom/hardware entropy sources.
+    ///
+    /// **Warning**: the security of the generated key rests entirely on the
+    /// quality of `rng`; a low-entropy, predictable, or reused generator yields
+    /// predictable or repeated keys. Pass a cryptographically secure generator
+    /// seeded with sufficient entropy.
+    pub fn new_with_rng<R: CryptoRng>(rng: &mut R) -> Self {
+        let signing_key = SigningKey::generate(rng);
         let key = Box::new(signing_key);
 
         Self(key)

--- a/src/types/ed25519.rs
+++ b/src/types/ed25519.rs
@@ -237,8 +237,8 @@ impl Ed25519SecretKey {
         Self(key)
     }
 
-    /// Create a new random `Ed25519SecretKey`, drawing entropy from the provided
-    /// random number generator.
+    /// Create a new random `Ed25519SecretKey`, drawing entropy from the
+    /// provided random number generator.
     ///
     /// This behaves exactly like [`Ed25519SecretKey::new`] but sources its
     /// randomness from the caller-supplied `rng` instead of the thread-local

--- a/tests/with_rng.rs
+++ b/tests/with_rng.rs
@@ -1,0 +1,228 @@
+// Copyright 2026 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the additive `*_with_rng` entropy-injection API.
+//!
+//! These verify that:
+//!   * supplying a deterministic RNG to every keygen `_with_rng` variant yields
+//!     reproducible keys, sessions, and ciphertext (same RNG state in => same
+//!     bytes out);
+//!   * distinct RNG states yield distinct keys (the RNG genuinely drives the
+//!     keygen);
+//!   * a `_with_rng`-built session interoperates with a default (`OsRng`-built)
+//!     counterpart, i.e. the seam is behaviour-preserving;
+//!   * the lazy Diffie-Hellman ratchet advance inside `encrypt` consumes RNG
+//!     bytes exactly when the ratchet turns, so a genuinely-new ratchet step is
+//!     reproducible under the same RNG but produces a fresh ephemeral under a
+//!     different one.
+
+use rand::{SeedableRng, rngs::StdRng};
+use vodozemac::olm::{Account, OlmMessage, Session, SessionConfig};
+
+/// A deterministic, seedable CSPRNG for reproducible test vectors.
+fn seeded(seed: u8) -> StdRng {
+    StdRng::from_seed([seed; 32])
+}
+
+#[test]
+fn account_new_with_rng_is_deterministic() {
+    let a = Account::new_with_rng(&mut seeded(1));
+    let b = Account::new_with_rng(&mut seeded(1));
+
+    assert_eq!(a.curve25519_key(), b.curve25519_key());
+    assert_eq!(a.ed25519_key(), b.ed25519_key());
+}
+
+#[test]
+fn account_new_with_rng_differs_for_distinct_seeds() {
+    let a = Account::new_with_rng(&mut seeded(1));
+    let b = Account::new_with_rng(&mut seeded(2));
+
+    assert_ne!(a.curve25519_key(), b.curve25519_key());
+    assert_ne!(a.ed25519_key(), b.ed25519_key());
+}
+
+#[test]
+fn generate_one_time_keys_with_rng_is_deterministic() {
+    let mut a = Account::new_with_rng(&mut seeded(3));
+    let mut b = Account::new_with_rng(&mut seeded(3));
+
+    let created_a = a.generate_one_time_keys_with_rng(5, &mut seeded(4)).created;
+    let created_b = b.generate_one_time_keys_with_rng(5, &mut seeded(4)).created;
+
+    assert_eq!(created_a, created_b);
+    assert_eq!(created_a.len(), 5);
+    // Distinct RNG => distinct one-time keys.
+    let created_c = b.generate_one_time_keys_with_rng(5, &mut seeded(7)).created;
+    assert_ne!(created_a, created_c);
+}
+
+#[test]
+fn generate_fallback_key_with_rng_is_deterministic() {
+    let mut a = Account::new_with_rng(&mut seeded(5));
+    let mut b = Account::new_with_rng(&mut seeded(5));
+
+    a.generate_fallback_key_with_rng(&mut seeded(6));
+    b.generate_fallback_key_with_rng(&mut seeded(6));
+
+    assert_eq!(a.fallback_key(), b.fallback_key());
+    assert!(!a.fallback_key().is_empty());
+}
+
+#[test]
+fn outbound_session_and_first_message_with_rng_is_deterministic() {
+    let build = || -> (String, OlmMessage) {
+        let mut bob = Account::new_with_rng(&mut seeded(10));
+        let bob_otk = *bob
+            .generate_one_time_keys_with_rng(1, &mut seeded(11))
+            .created
+            .first()
+            .expect("one OTK");
+
+        let alice = Account::new_with_rng(&mut seeded(12));
+        let mut session = alice
+            .create_outbound_session_with_rng(
+                SessionConfig::version_1(),
+                bob.curve25519_key(),
+                bob_otk,
+                &mut seeded(13),
+            )
+            .expect("outbound session");
+
+        let message = session.encrypt_with_rng("hello", &mut seeded(14)).expect("encrypt");
+        (session.session_id(), message)
+    };
+
+    let (id1, msg1) = build();
+    let (id2, msg2) = build();
+
+    assert_eq!(id1, id2, "session id must be reproducible for identical inputs");
+    assert_eq!(
+        msg1.to_parts(),
+        msg2.to_parts(),
+        "ciphertext must be byte-identical for identical (state, seed, plaintext)"
+    );
+}
+
+#[test]
+fn with_rng_session_interoperates_with_default_account() {
+    // Bob is built with the default (OsRng) path; Alice uses the `_with_rng`
+    // path. If the seam is behaviour-preserving they must be able to talk.
+    let mut bob = Account::new();
+    let bob_otk =
+        *bob.generate_one_time_keys(1).created.first().expect("one OTK");
+
+    let alice = Account::new_with_rng(&mut seeded(20));
+    let mut alice_session = alice
+        .create_outbound_session_with_rng(
+            SessionConfig::version_1(),
+            bob.curve25519_key(),
+            bob_otk,
+            &mut seeded(21),
+        )
+        .expect("outbound session");
+
+    let message =
+        alice_session.encrypt_with_rng("hello from with_rng", &mut seeded(22)).expect("encrypt");
+    let OlmMessage::PreKey(prekey) = message else {
+        panic!("first message must be a pre-key message");
+    };
+
+    let result = bob
+        .create_inbound_session(SessionConfig::version_1(), alice.curve25519_key(), &prekey)
+        .expect("inbound session");
+    assert_eq!(result.plaintext, b"hello from with_rng");
+
+    // And the reply direction: default-built Bob replies, Alice decrypts.
+    let mut bob_session = result.session;
+    let reply = bob_session.encrypt("hi back").expect("encrypt");
+    let plaintext = alice_session.decrypt(&reply).expect("alice decrypts reply");
+    assert_eq!(plaintext, b"hi back");
+}
+
+/// Build a fully deterministic Alice session that has received one reply from
+/// Bob, so its sending ratchet is *inactive*: the next `encrypt` performs a
+/// genuine Diffie-Hellman ratchet advance and therefore consumes RNG bytes.
+#[allow(clippy::expect_used, clippy::panic)]
+fn alice_ready_to_advance() -> Session {
+    let mut bob = Account::new_with_rng(&mut seeded(30));
+    let bob_otk = *bob
+        .generate_one_time_keys_with_rng(1, &mut seeded(31))
+        .created
+        .first()
+        .expect("one OTK");
+
+    let alice = Account::new_with_rng(&mut seeded(32));
+    let mut alice_session = alice
+        .create_outbound_session_with_rng(
+            SessionConfig::version_1(),
+            bob.curve25519_key(),
+            bob_otk,
+            &mut seeded(33),
+        )
+        .expect("outbound session");
+
+    let prekey = alice_session.encrypt_with_rng("hi", &mut seeded(34)).expect("encrypt");
+    let OlmMessage::PreKey(prekey) = prekey else { panic!("expected pre-key message") };
+
+    let mut bob_session = bob
+        .create_inbound_session(SessionConfig::version_1(), alice.curve25519_key(), &prekey)
+        .expect("inbound session")
+        .session;
+
+    // Bob replies; Alice decrypts, flipping her sending ratchet to inactive.
+    let reply = bob_session.encrypt_with_rng("re", &mut seeded(35)).expect("encrypt");
+    alice_session.decrypt(&reply).expect("alice decrypts reply");
+
+    alice_session
+}
+
+#[test]
+fn dh_ratchet_advance_is_reproducible_under_same_rng() {
+    // Same session state + same advance RNG => byte-identical advancing message,
+    // including the freshly minted ratchet public key embedded in the header.
+    //
+    // This is the load-bearing assertion for the encrypt seam: it pins that the
+    // *caller's* RNG (not a fresh internal `rng()`) drives the DH-ratchet mint.
+    // If `encrypt_with_rng` ever fell back to `OsRng`, this test would fail
+    // (whereas the distinct-RNG test below would still pass).
+    let mut a = alice_ready_to_advance();
+    let mut b = alice_ready_to_advance();
+
+    let msg_a = a.encrypt_with_rng("advance", &mut seeded(40)).expect("encrypt");
+    let msg_b = b.encrypt_with_rng("advance", &mut seeded(40)).expect("encrypt");
+
+    assert_eq!(msg_a.to_parts(), msg_b.to_parts());
+}
+
+#[test]
+fn dh_ratchet_advance_mints_fresh_ephemeral_under_distinct_rng() {
+    // Same session state, *different* advance RNG => the two genuinely-new DH
+    // steps produce distinct advancing messages (distinct ephemeral ratchet
+    // keys). This shows the advancing output is not frozen and responds to the
+    // supplied RNG. Note: on its own this would also pass if the mint ignored
+    // the caller's RNG and drew from OsRng — it is the reproducibility test
+    // above that pins the caller's RNG as the actual entropy source. Together
+    // they show a genuinely-new ratchet step is both driven by and fully
+    // determined by the supplied RNG, which is why reusing an RNG state across
+    // two distinct advancing steps would collapse the ephemeral (the documented
+    // forward-secrecy footgun).
+    let mut a = alice_ready_to_advance();
+    let mut b = alice_ready_to_advance();
+
+    let msg_a = a.encrypt_with_rng("advance", &mut seeded(40)).expect("encrypt");
+    let msg_b = b.encrypt_with_rng("advance", &mut seeded(41)).expect("encrypt");
+
+    assert_ne!(msg_a.to_parts(), msg_b.to_parts());
+}

--- a/tests/with_rng.rs
+++ b/tests/with_rng.rs
@@ -28,7 +28,10 @@
 //!     different one.
 
 use rand::{SeedableRng, rngs::StdRng};
-use vodozemac::olm::{Account, OlmMessage, Session, SessionConfig};
+use vodozemac::{
+    Ed25519SecretKey,
+    olm::{Account, OlmMessage, Session, SessionConfig},
+};
 
 /// A deterministic, seedable CSPRNG for reproducible test vectors.
 fn seeded(seed: u8) -> StdRng {
@@ -120,8 +123,7 @@ fn with_rng_session_interoperates_with_default_account() {
     // Bob is built with the default (OsRng) path; Alice uses the `_with_rng`
     // path. If the seam is behaviour-preserving they must be able to talk.
     let mut bob = Account::new();
-    let bob_otk =
-        *bob.generate_one_time_keys(1).created.first().expect("one OTK");
+    let bob_otk = *bob.generate_one_time_keys(1).created.first().expect("one OTK");
 
     let alice = Account::new_with_rng(&mut seeded(20));
     let mut alice_session = alice
@@ -157,11 +159,8 @@ fn with_rng_session_interoperates_with_default_account() {
 #[allow(clippy::expect_used, clippy::panic)]
 fn alice_ready_to_advance() -> Session {
     let mut bob = Account::new_with_rng(&mut seeded(30));
-    let bob_otk = *bob
-        .generate_one_time_keys_with_rng(1, &mut seeded(31))
-        .created
-        .first()
-        .expect("one OTK");
+    let bob_otk =
+        *bob.generate_one_time_keys_with_rng(1, &mut seeded(31)).created.first().expect("one OTK");
 
     let alice = Account::new_with_rng(&mut seeded(32));
     let mut alice_session = alice
@@ -225,4 +224,37 @@ fn dh_ratchet_advance_mints_fresh_ephemeral_under_distinct_rng() {
     let msg_b = b.encrypt_with_rng("advance", &mut seeded(41)).expect("encrypt");
 
     assert_ne!(msg_a.to_parts(), msg_b.to_parts());
+}
+
+#[test]
+fn ed25519_secret_key_with_rng_is_seed_driven() {
+    // Same seed => byte-identical key: the injected RNG fully determines the key.
+    let a = Ed25519SecretKey::new_with_rng(&mut seeded(1));
+    let b = Ed25519SecretKey::new_with_rng(&mut seeded(1));
+    assert_eq!(a.public_key(), b.public_key());
+
+    // Distinct seeds => distinct keys: the key genuinely comes from `rng`, not a
+    // constant. (Determinism alone would also hold for a key that ignored the
+    // RNG entirely; this divergence pins the RNG as the actual entropy source.)
+    let c = Ed25519SecretKey::new_with_rng(&mut seeded(2));
+    assert_ne!(a.public_key(), c.public_key());
+}
+
+#[test]
+fn fallback_key_with_rng_assigns_a_fresh_key_id_each_time() {
+    let mut account = Account::new_with_rng(&mut seeded(30));
+
+    account.generate_fallback_key_with_rng(&mut seeded(31));
+    let first_id = *account.fallback_key().keys().next().expect("a fallback key exists");
+
+    account.generate_fallback_key_with_rng(&mut seeded(32));
+    let second_id = *account.fallback_key().keys().next().expect("a fallback key exists");
+
+    // Each regeneration must advance the internal key-id counter so the new
+    // fallback key is published under a distinct KeyId; a counter that fails to
+    // increment would re-issue the same id.
+    assert_ne!(
+        first_id, second_id,
+        "each generated fallback key must receive a fresh, incrementing KeyId"
+    );
 }


### PR DESCRIPTION
### Summary
Adds additive `*_with_rng` variants to every key-generation entry point in the `olm`
module, letting callers supply their own `impl CryptoRng` instead of the thread-local
`rand::rng()`. Fully backwards-compatible: no existing method changes behaviour.

### Motivation
vodozemac currently sources all key-generation entropy from `rand::rng()` (the
thread-local, OS-seeded generator), with no way to inject a specific RNG. Exposing an
RNG parameter is a standard, widely-useful capability that `x25519-dalek` and
`ed25519-dalek` already provide at the primitive level
(`StaticSecret::random_from_rng`, `SigningKey::generate`). Surfacing it at the
`Account`/`Session` level enables:

- **Deterministic tests / KAT vectors** — reproduce exact keys and ciphertext from a
  fixed seed, so regressions in key-derivation plumbing are caught byte-for-byte.
- **Reproducible builds** and record/replay harnesses.
- **Custom or hardware entropy sources** — HSMs/TPMs, or a host that already owns a
  vetted CSPRNG and wants a single entropy source.
- **`no_std`/embedded targets** where `getrandom` has no backend and entropy must be
  provided by the caller.

### What changed
New `*_with_rng` methods, each taking `rng: &mut impl CryptoRng`:
- `Account::new_with_rng`
- `Account::generate_one_time_keys_with_rng`
- `Account::generate_fallback_key_with_rng`
- `Account::create_outbound_session_with_rng`
- `Session::encrypt_with_rng` — consumes RNG bytes **only** when the message triggers a
  Diffie-Hellman ratchet advance; a pure symmetric-chain message draws nothing.
- `Curve25519SecretKey::new_with_rng`, `Curve25519Keypair::new_with_rng`
- `Ed25519Keypair::new_with_rng`, `Ed25519SecretKey::new_with_rng`

The rng is threaded through internal helpers (`Ratchet`, `RemoteRootKey::advance`,
`DoubleRatchet`, `OneTimeKeys`, `FallbackKeys`) via parallel `_with_rng` methods.
`decrypt`/`create_inbound_session` are unchanged — they mint no keys.

### Non-breaking / additive
Every existing method keeps its exact body and behaviour, still backed by `rand::rng()`.
The diff is purely additive (the only two removed lines augment two `use` statements). No
public signature changes; no existing test changed. The audited `OsRng` code paths are
byte-identical.

### Security note (the footgun)
An injected RNG is a sharp tool: the security of every key rests entirely on the quality
of the supplied generator. A low-entropy, predictable, or **reused** RNG produces
predictable or repeated secret keys, and reusing an RNG state across two genuinely-new
Diffie-Hellman ratchet steps collapses the ephemeral keys and destroys forward secrecy /
post-compromise security. Each new public method documents this explicitly and directs
callers to pass a cryptographically secure generator seeded with fresh entropy per
genuinely-new operation. The default `OsRng`-backed methods remain the right choice for
almost all users.

### Tests
`tests/with_rng.rs` covers: determinism (identical RNG ⇒ byte-identical keys/session-id/
ciphertext across all seams); distinct RNG ⇒ distinct keys; interop (a `_with_rng`-built
session round-trips with a default `OsRng`-built peer); and the lazy DH-ratchet advance
seam (reproducible under the same RNG, fresh ephemeral under a different one). All
existing tests pass; `cargo clippy --all-targets --all-features` is clean.
