### PR TITLE
chore: Enable the unreachable_pub Rust lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ unsafe_op_in_unsafe_fn = "deny"
 unused_extern_crates = "deny"
 unused_import_braces = "deny"
 unused_qualifications = "deny"
+unreachable_pub = "deny"
 rust_2018_idioms = "deny"
 
 [lints.clippy]

--- a/src/cipher/key.rs
+++ b/src/cipher/key.rs
@@ -70,19 +70,19 @@ pub(crate) struct CipherKeys {
 }
 
 impl CipherKeys {
-    pub fn new(message_key: &[u8; 32]) -> Self {
+    pub(crate) fn new(message_key: &[u8; 32]) -> Self {
         let expanded_keys = ExpandedKeys::new(message_key);
 
         Self::from_expanded_keys(expanded_keys)
     }
 
-    pub fn new_megolm(message_key: &[u8; 128]) -> Self {
+    pub(crate) fn new_megolm(message_key: &[u8; 128]) -> Self {
         let expanded_keys = ExpandedKeys::new_megolm(message_key);
 
         Self::from_expanded_keys(expanded_keys)
     }
 
-    pub fn new_pickle(pickle_key: &[u8]) -> Self {
+    pub(crate) fn new_pickle(pickle_key: &[u8]) -> Self {
         let expanded_keys = ExpandedKeys::new_pickle(pickle_key);
 
         Self::from_expanded_keys(expanded_keys)
@@ -100,16 +100,16 @@ impl CipherKeys {
         Self { aes_key, aes_iv, mac_key }
     }
 
-    pub fn aes_key(&self) -> &Aes256Key {
+    pub(crate) fn aes_key(&self) -> &Aes256Key {
         #[allow(deprecated)]
         Aes256Key::from_slice(self.aes_key.as_slice())
     }
 
-    pub const fn mac_key(&self) -> &HmacSha256Key {
+    pub(crate) const fn mac_key(&self) -> &HmacSha256Key {
         &self.mac_key
     }
 
-    pub fn iv(&self) -> &Aes256Iv {
+    pub(crate) fn iv(&self) -> &Aes256Iv {
         #[allow(deprecated)]
         Aes256Iv::from_slice(self.aes_iv.as_slice())
     }

--- a/src/cipher/mod.rs
+++ b/src/cipher/mod.rs
@@ -33,16 +33,20 @@ pub(crate) type HmacSha256 = Hmac<Sha256>;
 
 /// The message authentication code of a ciphertext.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(unreachable_pub)]
 pub struct Mac(pub(crate) [u8; Self::LENGTH]);
 
 impl Mac {
     /// The expected length of the message authentication code (MAC).
+    #[allow(unreachable_pub)]
     pub const LENGTH: usize = 32;
     /// The expected length of the message authentication code (MAC) if
     /// truncation is applied.
+    #[allow(unreachable_pub)]
     pub const TRUNCATED_LEN: usize = 8;
 
     /// Truncates and converts the [`Mac`] into a byte array.
+    #[allow(unreachable_pub)]
     pub fn truncate(&self) -> [u8; Self::TRUNCATED_LEN] {
         let mut truncated = [0u8; Self::TRUNCATED_LEN];
         truncated.copy_from_slice(&self.0[0..Self::TRUNCATED_LEN]);
@@ -51,6 +55,7 @@ impl Mac {
     }
 
     /// Return the [`Mac`] as a byte slice.
+    #[allow(unreachable_pub)]
     pub fn as_bytes(&self) -> &[u8] {
         self.0.as_ref()
     }
@@ -63,7 +68,7 @@ pub(crate) enum MessageMac {
 }
 
 impl MessageMac {
-    pub fn as_bytes(&self) -> &[u8] {
+    pub(crate) fn as_bytes(&self) -> &[u8] {
         match self {
             MessageMac::Truncated(m) => m.as_ref(),
             MessageMac::Full(m) => m.as_bytes(),
@@ -94,6 +99,7 @@ pub enum DecryptionError {
 }
 
 /// A cipher used for encrypting and decrypting messages.
+#[allow(unreachable_pub)]
 pub struct Cipher {
     keys: CipherKeys,
 }
@@ -107,6 +113,7 @@ impl Cipher {
     ///
     /// This key derivation format is typically used for generating individual
     /// message keys in the Olm double ratchet.
+    #[allow(unreachable_pub)]
     pub fn new(key: &[u8; 32]) -> Self {
         let keys = CipherKeys::new(key);
 
@@ -122,6 +129,7 @@ impl Cipher {
     ///
     /// This key derivation format is typically used for generating individual
     /// message keys in the Megolm ratchet.
+    #[allow(unreachable_pub)]
     pub fn new_megolm(&key: &[u8; 128]) -> Self {
         let keys = CipherKeys::new_megolm(&key);
 
@@ -138,6 +146,7 @@ impl Cipher {
     ///
     /// This key derivation format is typically used for libolm-compatible
     /// encrypted pickle formats.
+    #[allow(unreachable_pub)]
     pub fn new_pickle(key: &[u8]) -> Self {
         let keys = CipherKeys::new_pickle(key);
 
@@ -160,6 +169,7 @@ impl Cipher {
     /// **Warning**: This is a low-level function and does not provide
     /// authentication for the ciphertext. You must call [`Cipher::mac()`]
     /// separately to generate the message authentication code (MAC).
+    #[allow(unreachable_pub)]
     pub fn encrypt(&self, plaintext: &[u8]) -> Vec<u8> {
         let cipher = Aes256CbcEnc::new(self.keys.aes_key(), self.keys.iv());
         cipher.encrypt_padded_vec::<Pkcs7>(plaintext)
@@ -170,6 +180,7 @@ impl Cipher {
     /// **Warning**: This is a low-level function and must be called after the
     /// [`Cipher::encrypt`] method. The ciphertext produced by
     /// [`Cipher::encrypt`] must be passed as the argument to this method.
+    #[allow(unreachable_pub)]
     pub fn mac(&self, message: &[u8]) -> Mac {
         let mut hmac = self.get_hmac();
         hmac.update(message);
@@ -187,6 +198,7 @@ impl Cipher {
     /// **Warning**: This is a low-level function. Before calling this, you must
     /// call [`Cipher::verify_mac()`] or [`Cipher::verify_truncated_mac()`]
     /// to ensure the integrity of the ciphertext.
+    #[allow(unreachable_pub)]
     pub fn decrypt(&self, ciphertext: &[u8]) -> Result<Vec<u8>, UnpadError> {
         let cipher = Aes256CbcDec::new(self.keys.aes_key(), self.keys.iv());
         cipher.decrypt_padded_vec::<Pkcs7>(ciphertext)
@@ -198,6 +210,7 @@ impl Cipher {
     /// **Warning**: This is a low-level function and must be called before
     /// invoking the [`Cipher::decrypt()`] method.
     #[cfg(all(not(fuzzing), feature = "experimental-session-config"))]
+    #[allow(unreachable_pub)]
     pub fn verify_mac(&self, message: &[u8], tag: &Mac) -> Result<(), MacError> {
         let mut hmac = self.get_hmac();
 
@@ -211,6 +224,7 @@ impl Cipher {
     /// **Warning**: This is a low-level function and must be called before
     /// invoking the [`Cipher::decrypt()`] method.
     #[cfg(not(fuzzing))]
+    #[allow(unreachable_pub)]
     pub fn verify_truncated_mac(&self, message: &[u8], tag: &[u8]) -> Result<(), MacError> {
         let mut hmac = self.get_hmac();
 
@@ -251,6 +265,7 @@ impl Cipher {
     /// message authentication tag to it.
     ///
     /// This follows the encryption method used by the libolm pickle format.
+    #[allow(unreachable_pub)]
     pub fn encrypt_pickle(&self, plaintext: &[u8]) -> Vec<u8> {
         let mut ciphertext = self.encrypt(plaintext);
         let mac = self.mac(&ciphertext);
@@ -267,6 +282,7 @@ impl Cipher {
     /// MAC before decrypting the ciphertext.
     ///
     /// This follows the encryption method used by the libolm pickle format.
+    #[allow(unreachable_pub)]
     pub fn decrypt_pickle(&self, ciphertext: &[u8]) -> Result<Vec<u8>, DecryptionError> {
         if ciphertext.len() < Mac::TRUNCATED_LEN + 1 {
             Err(DecryptionError::MacMissing)

--- a/src/megolm/ratchet.rs
+++ b/src/megolm/ratchet.rs
@@ -134,11 +134,11 @@ impl<'a> RatchetParts<'a> {
 }
 
 impl Ratchet {
-    pub const RATCHET_LENGTH: usize = 128;
+    pub(super) const RATCHET_LENGTH: usize = 128;
     const RATCHET_PART_COUNT: usize = 4;
     const LAST_RATCHET_INDEX: usize = Self::RATCHET_PART_COUNT - 1;
 
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         let mut rng = rng();
 
         let mut ratchet =
@@ -149,20 +149,20 @@ impl Ratchet {
         ratchet
     }
 
-    pub const fn from_bytes(bytes: Box<[u8; Self::RATCHET_LENGTH]>, counter: u32) -> Self {
+    pub(super) const fn from_bytes(bytes: Box<[u8; Self::RATCHET_LENGTH]>, counter: u32) -> Self {
         Self { inner: RatchetBytes(bytes), counter }
     }
 
-    pub const fn index(&self) -> u32 {
+    pub(super) const fn index(&self) -> u32 {
         self.counter
     }
 
-    pub const fn as_bytes(&self) -> &[u8; Self::RATCHET_LENGTH] {
+    pub(super) const fn as_bytes(&self) -> &[u8; Self::RATCHET_LENGTH] {
         &self.inner.0
     }
 
     #[cfg(test)]
-    pub const fn ratchet_bytes_pointer(&self) -> *const [u8; 128] {
+    pub(super) const fn ratchet_bytes_pointer(&self) -> *const [u8; 128] {
         &*self.inner.0
     }
 
@@ -180,7 +180,7 @@ impl Ratchet {
         RatchetParts { r_0, r_1, r_2, r_3 }
     }
 
-    pub fn advance(&mut self) {
+    pub(super) fn advance(&mut self) {
         let mut mask: u32 = 0x00FFFFFF;
 
         // The index of the "slowest" part of the ratchet that needs to be
@@ -208,7 +208,7 @@ impl Ratchet {
         }
     }
 
-    pub fn advance_to(&mut self, advance_to: u32) {
+    pub(super) fn advance_to(&mut self, advance_to: u32) {
         for j in 0..Self::RATCHET_PART_COUNT {
             let shift = (Self::LAST_RATCHET_INDEX - j) * 8;
             let mask: u32 = !0u32 << shift;

--- a/src/olm/account/fallback_keys.rs
+++ b/src/olm/account/fallback_keys.rs
@@ -33,23 +33,23 @@ impl FallbackKey {
         Self { key_id, key, published: false }
     }
 
-    pub fn public_key(&self) -> Curve25519PublicKey {
+    pub(super) fn public_key(&self) -> Curve25519PublicKey {
         Curve25519PublicKey::from(&self.key)
     }
 
-    pub const fn secret_key(&self) -> &Curve25519SecretKey {
+    pub(super) const fn secret_key(&self) -> &Curve25519SecretKey {
         &self.key
     }
 
-    pub const fn key_id(&self) -> KeyId {
+    pub(super) const fn key_id(&self) -> KeyId {
         self.key_id
     }
 
-    pub fn mark_as_published(&mut self) {
+    pub(super) fn mark_as_published(&mut self) {
         self.published = true;
     }
 
-    pub const fn published(&self) -> bool {
+    pub(super) const fn published(&self) -> bool {
         self.published
     }
 }
@@ -62,17 +62,17 @@ pub(super) struct FallbackKeys {
 }
 
 impl FallbackKeys {
-    pub const fn new() -> Self {
+    pub(super) const fn new() -> Self {
         Self { key_id: 0, fallback_key: None, previous_fallback_key: None }
     }
 
-    pub fn mark_as_published(&mut self) {
+    pub(super) fn mark_as_published(&mut self) {
         if let Some(f) = self.fallback_key.as_mut() {
             f.mark_as_published()
         }
     }
 
-    pub fn generate_fallback_key(&mut self) -> Option<Curve25519PublicKey> {
+    pub(super) fn generate_fallback_key(&mut self) -> Option<Curve25519PublicKey> {
         let key_id = KeyId(self.key_id);
         self.key_id += 1;
 
@@ -84,7 +84,10 @@ impl FallbackKeys {
         ret
     }
 
-    pub fn get_secret_key(&self, public_key: &Curve25519PublicKey) -> Option<&Curve25519SecretKey> {
+    pub(super) fn get_secret_key(
+        &self,
+        public_key: &Curve25519PublicKey,
+    ) -> Option<&Curve25519SecretKey> {
         self.fallback_key
             .as_ref()
             .filter(|f| f.public_key() == *public_key)
@@ -94,11 +97,11 @@ impl FallbackKeys {
             .map(|f| f.secret_key())
     }
 
-    pub fn forget_previous_fallback_key(&mut self) -> Option<FallbackKey> {
+    pub(super) fn forget_previous_fallback_key(&mut self) -> Option<FallbackKey> {
         self.previous_fallback_key.take()
     }
 
-    pub fn unpublished_fallback_key(&self) -> Option<&FallbackKey> {
+    pub(super) fn unpublished_fallback_key(&self) -> Option<&FallbackKey> {
         self.fallback_key.as_ref().filter(|f| !f.published())
     }
 }

--- a/src/olm/account/one_time_keys.rs
+++ b/src/olm/account/one_time_keys.rs
@@ -44,7 +44,7 @@ pub struct OneTimeKeyGenerationResult {
 impl OneTimeKeys {
     const MAX_ONE_TIME_KEYS: usize = 100 * PUBLIC_MAX_ONE_TIME_KEYS;
 
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             next_key_id: 0,
             unpublished_public_keys: Default::default(),
@@ -53,15 +53,18 @@ impl OneTimeKeys {
         }
     }
 
-    pub fn mark_as_published(&mut self) {
+    pub(super) fn mark_as_published(&mut self) {
         self.unpublished_public_keys.clear();
     }
 
-    pub fn get_secret_key(&self, public_key: &Curve25519PublicKey) -> Option<&Curve25519SecretKey> {
+    pub(super) fn get_secret_key(
+        &self,
+        public_key: &Curve25519PublicKey,
+    ) -> Option<&Curve25519SecretKey> {
         self.key_ids_by_key.get(public_key).and_then(|key_id| self.private_keys.get(key_id))
     }
 
-    pub fn remove_secret_key(
+    pub(super) fn remove_secret_key(
         &mut self,
         public_key: &Curve25519PublicKey,
     ) -> Option<Curve25519SecretKey> {
@@ -127,7 +130,7 @@ impl OneTimeKeys {
         !self.unpublished_public_keys.contains_key(key_id)
     }
 
-    pub fn generate(&mut self, count: usize) -> OneTimeKeyGenerationResult {
+    pub(super) fn generate(&mut self, count: usize) -> OneTimeKeyGenerationResult {
         let mut removed_keys = Vec::new();
         let mut created_keys = Vec::new();
 

--- a/src/olm/session/chain_key.rs
+++ b/src/olm/session/chain_key.rs
@@ -65,27 +65,27 @@ pub(super) struct RemoteChainKey {
 }
 
 impl RemoteChainKey {
-    pub const fn new(bytes: Box<[u8; 32]>) -> Self {
+    pub(super) const fn new(bytes: Box<[u8; 32]>) -> Self {
         Self { key: bytes, index: 0 }
     }
 
-    pub const fn chain_index(&self) -> u64 {
+    pub(super) const fn chain_index(&self) -> u64 {
         self.index
     }
 
     #[cfg(feature = "libolm-compat")]
-    pub fn from_bytes_and_index(bytes: Box<[u8; 32]>, index: u32) -> Self {
+    pub(super) fn from_bytes_and_index(bytes: Box<[u8; 32]>, index: u32) -> Self {
         Self { key: bytes, index: index.into() }
     }
 
-    pub fn advance(&mut self) {
+    pub(super) fn advance(&mut self) {
         let output = advance(&self.key).into_bytes();
         #[allow(deprecated)]
         self.key.copy_from_slice(output.as_slice());
         self.index += 1;
     }
 
-    pub fn create_message_key(&mut self) -> RemoteMessageKey {
+    pub(super) fn create_message_key(&mut self) -> RemoteMessageKey {
         let key = expand_chain_key(&self.key);
         let message_key = RemoteMessageKey::new(key, self.index);
 
@@ -96,27 +96,27 @@ impl RemoteChainKey {
 }
 
 impl ChainKey {
-    pub const fn new(bytes: Box<[u8; 32]>) -> Self {
+    pub(super) const fn new(bytes: Box<[u8; 32]>) -> Self {
         Self { key: bytes, index: 0 }
     }
 
     #[cfg(feature = "libolm-compat")]
-    pub fn from_bytes_and_index(bytes: Box<[u8; 32]>, index: u32) -> Self {
+    pub(super) fn from_bytes_and_index(bytes: Box<[u8; 32]>, index: u32) -> Self {
         Self { key: bytes, index: index.into() }
     }
 
-    pub fn advance(&mut self) {
+    pub(super) fn advance(&mut self) {
         let output = advance(&self.key).into_bytes();
         #[allow(deprecated)]
         self.key.copy_from_slice(output.as_slice());
         self.index += 1;
     }
 
-    pub const fn index(&self) -> u64 {
+    pub(super) const fn index(&self) -> u64 {
         self.index
     }
 
-    pub fn create_message_key(&mut self, ratchet_key: RatchetPublicKey) -> MessageKey {
+    pub(super) fn create_message_key(&mut self, ratchet_key: RatchetPublicKey) -> MessageKey {
         let key = expand_chain_key(&self.key);
         let message_key = MessageKey::new(key, ratchet_key, self.index);
 

--- a/src/olm/session/double_ratchet.rs
+++ b/src/olm/session/double_ratchet.rs
@@ -49,7 +49,7 @@ pub(super) struct DoubleRatchet {
 }
 
 impl DoubleRatchet {
-    pub fn next_message_key(&mut self) -> Option<MessageKey> {
+    pub(super) fn next_message_key(&mut self) -> Option<MessageKey> {
         match &mut self.inner {
             DoubleRatchetState::Inactive(ratchet) => {
                 let mut ratchet = ratchet.activate()?;
@@ -64,11 +64,14 @@ impl DoubleRatchet {
     }
 
     #[cfg(feature = "experimental-session-config")]
-    pub fn encrypt(&mut self, plaintext: &[u8]) -> Result<Message, EncryptionError> {
+    pub(super) fn encrypt(&mut self, plaintext: &[u8]) -> Result<Message, EncryptionError> {
         Ok(self.next_message_key().ok_or(EncryptionError::NonContributoryKey)?.encrypt(plaintext))
     }
 
-    pub fn encrypt_truncated_mac(&mut self, plaintext: &[u8]) -> Result<Message, EncryptionError> {
+    pub(super) fn encrypt_truncated_mac(
+        &mut self,
+        plaintext: &[u8],
+    ) -> Result<Message, EncryptionError> {
         Ok(self
             .next_message_key()
             .ok_or(EncryptionError::NonContributoryKey)?
@@ -77,7 +80,7 @@ impl DoubleRatchet {
 
     /// Create a new `DoubleRatchet` instance, based on a newly-calculated
     /// shared secret.
-    pub fn active(shared_secret: Shared3DHSecret) -> Self {
+    pub(super) fn active(shared_secret: Shared3DHSecret) -> Self {
         let (root_key, chain_key) = shared_secret.expand();
 
         let root_key = RootKey::new(root_key);
@@ -94,7 +97,7 @@ impl DoubleRatchet {
     }
 
     #[cfg(feature = "libolm-compat")]
-    pub fn from_ratchet_and_chain_key(ratchet: Ratchet, chain_key: ChainKey) -> Self {
+    pub(super) fn from_ratchet_and_chain_key(ratchet: Ratchet, chain_key: ChainKey) -> Self {
         Self {
             inner: ActiveDoubleRatchet {
                 parent_ratchet_key: None, // libolm pickle did not record parent ratchet key
@@ -106,7 +109,7 @@ impl DoubleRatchet {
         }
     }
 
-    pub fn inactive_from_prekey_data(
+    pub(super) fn inactive_from_prekey_data(
         root_key: RemoteRootKey,
         ratchet_key: RemoteRatchetKey,
     ) -> Self {
@@ -117,7 +120,7 @@ impl DoubleRatchet {
     }
 
     #[cfg(feature = "libolm-compat")]
-    pub fn inactive_from_libolm_pickle(
+    pub(super) fn inactive_from_libolm_pickle(
         root_key: RemoteRootKey,
         ratchet_key: RemoteRatchetKey,
     ) -> Self {
@@ -162,7 +165,7 @@ impl DoubleRatchet {
         })
     }
 
-    pub fn advance(
+    pub(super) fn advance(
         &mut self,
         ratchet_key: RemoteRatchetKey,
     ) -> Option<(DoubleRatchet, ReceiverChain)> {
@@ -342,21 +345,21 @@ impl Debug for ActiveDoubleRatchet {
 /// It may be unknown, if the ratchet was restored from a pickle
 /// which didn't track it.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub enum RatchetCount {
+pub(super) enum RatchetCount {
     Known(u64),
     Unknown(()),
 }
 
 impl RatchetCount {
-    pub const fn new() -> RatchetCount {
+    pub(super) const fn new() -> RatchetCount {
         RatchetCount::Known(0)
     }
 
-    pub const fn unknown() -> RatchetCount {
+    pub(super) const fn unknown() -> RatchetCount {
         RatchetCount::Unknown(())
     }
 
-    pub fn advance(&self) -> RatchetCount {
+    pub(super) fn advance(&self) -> RatchetCount {
         match self {
             RatchetCount::Known(count) => RatchetCount::Known(count + 1),
             RatchetCount::Unknown(_) => RatchetCount::Unknown(()),

--- a/src/olm/session/message_key.rs
+++ b/src/olm/session/message_key.rs
@@ -26,6 +26,7 @@ use crate::{
 /// A single-use encryption key for per-message encryption.
 ///
 /// This key is used to encrypt a single message in an Olm session.
+#[allow(unreachable_pub)]
 pub struct MessageKey {
     key: Box<[u8; 32]>,
     ratchet_key: RatchetPublicKey,
@@ -64,6 +65,7 @@ impl MessageKey {
     ///
     /// The ratchet key and index will be included in the created [`Message`],
     /// allowing the message recipient to derive the same [`MessageKey`].
+    #[allow(unreachable_pub)]
     pub const fn new(key: Box<[u8; 32]>, ratchet_key: RatchetPublicKey, index: u64) -> Self {
         Self { key, ratchet_key, index }
     }
@@ -75,6 +77,7 @@ impl MessageKey {
     /// to be truncated, please take a look at the
     /// [`MessageKey::encrypt_truncated_mac()`] method instead.
     #[cfg(feature = "experimental-session-config")]
+    #[allow(unreachable_pub)]
     pub fn encrypt(self, plaintext: &[u8]) -> Message {
         let cipher = Cipher::new(&self.key);
 
@@ -93,6 +96,7 @@ impl MessageKey {
     /// This method authenticates the ciphertext with an 8-byte message
     /// authentication code (MAC). If you require the full, non-truncated
     /// MAC, refer to the [`MessageKey::encrypt()`] method.
+    #[allow(unreachable_pub)]
     pub fn encrypt_truncated_mac(self, plaintext: &[u8]) -> Message {
         let cipher = Cipher::new(&self.key);
 
@@ -127,15 +131,18 @@ impl MessageKey {
 }
 
 impl RemoteMessageKey {
-    pub const fn new(key: Box<[u8; 32]>, index: u64) -> Self {
+    pub(super) const fn new(key: Box<[u8; 32]>, index: u64) -> Self {
         Self { key, index }
     }
 
-    pub const fn chain_index(&self) -> u64 {
+    pub(super) const fn chain_index(&self) -> u64 {
         self.index
     }
 
-    pub fn decrypt_truncated_mac(&self, message: &Message) -> Result<Vec<u8>, DecryptionError> {
+    pub(super) fn decrypt_truncated_mac(
+        &self,
+        message: &Message,
+    ) -> Result<Vec<u8>, DecryptionError> {
         let cipher = Cipher::new(&self.key);
 
         if let crate::cipher::MessageMac::Truncated(m) = &message.mac {
@@ -147,7 +154,7 @@ impl RemoteMessageKey {
     }
 
     #[cfg(feature = "experimental-session-config")]
-    pub fn decrypt(&self, message: &Message) -> Result<Vec<u8>, DecryptionError> {
+    pub(super) fn decrypt(&self, message: &Message) -> Result<Vec<u8>, DecryptionError> {
         let cipher = Cipher::new(&self.key);
 
         if let crate::cipher::MessageMac::Full(m) = &message.mac {

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -15,8 +15,8 @@
 
 mod chain_key;
 mod double_ratchet;
-pub mod message_key;
-pub mod ratchet;
+pub(crate) mod message_key;
+pub(crate) mod ratchet;
 mod receiver_chain;
 mod root_key;
 
@@ -125,12 +125,12 @@ impl ChainStore {
     }
 
     #[cfg(test)]
-    pub const fn len(&self) -> usize {
+    pub(crate) const fn len(&self) -> usize {
         self.inner.len()
     }
 
     #[cfg(feature = "libolm-compat")]
-    pub fn get(&self, index: usize) -> Option<&ReceiverChain> {
+    pub(crate) fn get(&self, index: usize) -> Option<&ReceiverChain> {
         self.inner.get(index)
     }
 
@@ -700,7 +700,7 @@ mod test {
     /// Create a pair of accounts, one using vodozemac and one libolm.
     ///
     /// Then, create a pair of sessions between the two.
-    pub fn session_and_libolm_pair() -> Result<(Account, OlmAccount, Session, OlmSession)> {
+    pub(crate) fn session_and_libolm_pair() -> Result<(Account, OlmAccount, Session, OlmSession)> {
         let alice = Account::new();
         let bob = OlmAccount::new();
         bob.generate_one_time_keys(1);

--- a/src/olm/session/ratchet.rs
+++ b/src/olm/session/ratchet.rs
@@ -59,11 +59,11 @@ impl Debug for RemoteRatchetKey {
 }
 
 impl RatchetKey {
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self(Curve25519SecretKey::new())
     }
 
-    pub fn diffie_hellman(&self, other: &RemoteRatchetKey) -> Option<SharedSecret> {
+    pub(super) fn diffie_hellman(&self, other: &RemoteRatchetKey) -> Option<SharedSecret> {
         self.0.diffie_hellman(&other.0)
     }
 }
@@ -123,24 +123,27 @@ pub(super) struct Ratchet {
 }
 
 impl Ratchet {
-    pub fn new(root_key: RootKey) -> Self {
+    pub(super) fn new(root_key: RootKey) -> Self {
         let ratchet_key = RatchetKey::new();
 
         Self { root_key, ratchet_key }
     }
 
-    pub const fn new_with_ratchet_key(root_key: RootKey, ratchet_key: RatchetKey) -> Self {
+    pub(super) const fn new_with_ratchet_key(root_key: RootKey, ratchet_key: RatchetKey) -> Self {
         Self { root_key, ratchet_key }
     }
 
-    pub fn advance(&self, remote_key: RemoteRatchetKey) -> Option<(RemoteRootKey, RemoteChainKey)> {
+    pub(super) fn advance(
+        &self,
+        remote_key: RemoteRatchetKey,
+    ) -> Option<(RemoteRootKey, RemoteChainKey)> {
         let (remote_root_key, remote_chain_key) =
             self.root_key.advance(&self.ratchet_key, &remote_key)?;
 
         Some((remote_root_key, remote_chain_key))
     }
 
-    pub const fn ratchet_key(&self) -> &RatchetKey {
+    pub(super) const fn ratchet_key(&self) -> &RatchetKey {
         &self.ratchet_key
     }
 }

--- a/src/olm/session/receiver_chain.rs
+++ b/src/olm/session/receiver_chain.rs
@@ -170,7 +170,7 @@ impl Debug for ReceiverChain {
 }
 
 impl ReceiverChain {
-    pub fn new(
+    pub(super) fn new(
         ratchet_key: RemoteRatchetKey,
         chain_key: RemoteChainKey,
         ratchet_count: RatchetCount,
@@ -224,7 +224,7 @@ impl ReceiverChain {
         }
     }
 
-    pub fn decrypt(
+    pub(super) fn decrypt(
         &mut self,
         message: &Message,
         config: &SessionConfig,
@@ -251,16 +251,16 @@ impl ReceiverChain {
     }
 
     #[cfg(feature = "libolm-compat")]
-    pub const fn ratchet_key(&self) -> RemoteRatchetKey {
+    pub(super) const fn ratchet_key(&self) -> RemoteRatchetKey {
         self.ratchet_key
     }
 
     #[cfg(feature = "libolm-compat")]
-    pub fn insert_message_key(&mut self, message_key: RemoteMessageKey) {
+    pub(super) fn insert_message_key(&mut self, message_key: RemoteMessageKey) {
         self.skipped_message_keys.push(message_key)
     }
 
-    pub fn belongs_to(&self, ratchet_key: &RemoteRatchetKey) -> bool {
+    pub(super) fn belongs_to(&self, ratchet_key: &RemoteRatchetKey) -> bool {
         &self.ratchet_key == ratchet_key
     }
 }

--- a/src/olm/shared_secret.rs
+++ b/src/olm/shared_secret.rs
@@ -39,10 +39,10 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 use crate::{Curve25519PublicKey as PublicKey, types::Curve25519SecretKey as StaticSecret};
 
 #[derive(Zeroize, ZeroizeOnDrop)]
-pub struct Shared3DHSecret(Box<[u8; 96]>);
+pub(super) struct Shared3DHSecret(Box<[u8; 96]>);
 
 #[derive(Zeroize, ZeroizeOnDrop)]
-pub struct RemoteShared3DHSecret(Box<[u8; 96]>);
+pub(super) struct RemoteShared3DHSecret(Box<[u8; 96]>);
 
 fn expand(shared_secret: &[u8; 96]) -> (Box<[u8; 32]>, Box<[u8; 32]>) {
     let hkdf: Hkdf<Sha256> = Hkdf::new(Some(&[0]), shared_secret);
@@ -91,7 +91,7 @@ impl RemoteShared3DHSecret {
         Some(Self(merge_secrets(first_secret, second_secret, third_secret)))
     }
 
-    pub fn expand(self) -> (Box<[u8; 32]>, Box<[u8; 32]>) {
+    pub(super) fn expand(self) -> (Box<[u8; 32]>, Box<[u8; 32]>) {
         expand(&self.0)
     }
 }
@@ -110,7 +110,7 @@ impl Shared3DHSecret {
         Some(Self(merge_secrets(first_secret, second_secret, third_secret)))
     }
 
-    pub fn expand(self) -> (Box<[u8; 32]>, Box<[u8; 32]>) {
+    pub(super) fn expand(self) -> (Box<[u8; 32]>, Box<[u8; 32]>) {
         expand(&self.0)
     }
 }

--- a/src/types/curve25519.rs
+++ b/src/types/curve25519.rs
@@ -85,25 +85,25 @@ pub(crate) struct Curve25519Keypair {
 }
 
 impl Curve25519Keypair {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         let secret_key = Curve25519SecretKey::new();
         let public_key = Curve25519PublicKey::from(&secret_key);
 
         Self { secret_key, public_key }
     }
 
-    pub fn from_secret_key(key: &[u8; 32]) -> Self {
+    pub(crate) fn from_secret_key(key: &[u8; 32]) -> Self {
         let secret_key = Curve25519SecretKey::from_slice(key);
         let public_key = Curve25519PublicKey::from(&secret_key);
 
         Curve25519Keypair { secret_key, public_key }
     }
 
-    pub const fn secret_key(&self) -> &Curve25519SecretKey {
+    pub(crate) const fn secret_key(&self) -> &Curve25519SecretKey {
         &self.secret_key
     }
 
-    pub const fn public_key(&self) -> Curve25519PublicKey {
+    pub(crate) const fn public_key(&self) -> Curve25519PublicKey {
         self.public_key
     }
 }
@@ -250,10 +250,11 @@ impl From<Curve25519Keypair> for Curve25519KeypairPickle {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
+    use base64::DecodeError;
     use insta::assert_debug_snapshot;
 
     use super::Curve25519PublicKey;
-    use crate::{Curve25519SecretKey, KeyError, utilities::DecodeError};
+    use crate::{Curve25519SecretKey, KeyError};
 
     #[test]
     fn decoding_invalid_base64_fails() {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,9 +17,9 @@ mod ed25519;
 
 pub(crate) use curve25519::{Curve25519Keypair, Curve25519KeypairPickle};
 pub use curve25519::{Curve25519PublicKey, Curve25519SecretKey};
+pub(crate) use ed25519::Ed25519KeypairPickle;
 pub use ed25519::{
-    Ed25519Keypair, Ed25519KeypairPickle, Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature,
-    SignatureError,
+    Ed25519Keypair, Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature, SignatureError,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -15,9 +15,8 @@
 
 mod libolm_compat;
 
-pub use base64::DecodeError;
 use base64::{
-    Engine, alphabet,
+    DecodeError, Engine, alphabet,
     engine::{GeneralPurpose, general_purpose},
 };
 pub(crate) use libolm_compat::get_version as get_pickle_version;


### PR DESCRIPTION
This makes it more explicit and obvious which items are public and which are not.

It also caught some re-exports that didn't make it to the public API level. Some exceptions are also necessary due to us having exports available only under a feature flag.