### PR TITLE
Mark some of the indices in olm/megolm messages as required

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ zeroize = { version = "1.9.0", features = ["derive"] }
 anyhow = "1.0.103"
 assert_matches2 = "0.1.2"
 criterion = { version = "5.0.1", package = "codspeed-criterion-compat" }
-ntest = "0.9.5"
 olm-rs = "2.2.0"
 proptest = "1.11.0"
 insta = "1.48.0"

--- a/src/hpke/recipient.rs
+++ b/src/hpke/recipient.rs
@@ -186,8 +186,9 @@ impl UnidirectionalRecipientChannel {
             application_info_prefix,
         }) = self;
 
-        // Per [MSC4388] (and the HTTP [RFC 9458] where this trick is cribbed from), the
-        // length of the response nonce should be equal to the AEAD key size
+        // Per [MSC4388] (and the HTTP [RFC 9458] where this trick is cribbed
+        // from), the length of the response nonce should be equal to
+        // the AEAD key size
         //
         // [MSC4388]: https://github.com/matrix-org/matrix-spec-proposals/pull/4388
         // [RFC9458]: https://datatracker.ietf.org/doc/html/rfc9458

--- a/src/hpke/response_context.rs
+++ b/src/hpke/response_context.rs
@@ -65,20 +65,20 @@ pub(super) trait CreateResponseContext {
     ) -> Self::ResponseContext {
         let mut secret = [0u8; AeadKeySize::USIZE];
 
-        // Export a secret from the HPKE context, we use our application info prefix and
-        // append "_RESPONSE" to it.
+        // Export a secret from the HPKE context, we use our application info
+        // prefix and append "_RESPONSE" to it.
         let info = format!("{application_info_prefix}_RESPONSE");
 
         #[allow(clippy::expect_used)]
         self.export(info.as_bytes(), &mut secret)
             .expect("We should be able to export 32 bytes from the HPKE export interface");
 
-        // For the salt we concatenate the public key of the sender and the randomly
-        // generated response nonce.
+        // For the salt we concatenate the public key of the sender and the
+        // randomly generated response nonce.
         let salt: Vec<u8> = [encapsulated_key.as_bytes().as_slice(), response_nonce].concat();
 
-        // Now create a KDF from the salt and the previously secret exported from the
-        // HPKE context.
+        // Now create a KDF from the salt and the previously secret exported
+        // from the HPKE context.
         let hkdf = Hkdf::<Sha256>::new(Some(&salt), &secret);
 
         // From the KDF expand an AEAD key and nonce.
@@ -93,16 +93,16 @@ pub(super) trait CreateResponseContext {
         hkdf.expand(b"nonce", aead_nonce.0.as_mut_slice())
             .expect("We should be able to expand the base response secret into a response nonce");
 
-        // Check that our key and nonce aren't just zeroes, this is only checked in
-        // debug builds.
+        // Check that our key and nonce aren't just zeroes, this is only checked
+        // in debug builds.
         debug_assert_ne!(aead_nonce.0.as_slice(), [0u8; 12]);
         debug_assert_ne!(aead_key.0.as_slice(), [0u8; 32]);
 
         // Let's get rid of the secret.
         secret.zeroize();
 
-        // Now create a HPKE context which can be used to communicate in the other
-        // direction.
+        // Now create a HPKE context which can be used to communicate in the
+        // other direction.
         self.create_context(&aead_key, aead_nonce)
     }
 }

--- a/src/megolm/inbound_group_session.rs
+++ b/src/megolm/inbound_group_session.rs
@@ -561,8 +561,8 @@ mod test {
         let session_key = outbound_session.session_key();
         let message = outbound_session.encrypt("Hello");
 
-        // Not let's create a cipher that should be able to verify the MAC of the
-        // message.
+        // Not let's create a cipher that should be able to verify the MAC of
+        // the message.
         let mut session = InboundGroupSession::new(&session_key, session_config);
         let ratchet = session.find_ratchet(0).unwrap();
         let cipher = Cipher::new_megolm(ratchet.as_bytes());
@@ -669,7 +669,8 @@ mod test {
 
         let mut first_session = InboundGroupSession::new(&session_key, Default::default());
 
-        // This one is less trusted because it's imported from an `ExportedSessionKey`.
+        // This one is less trusted because it's imported from an
+        // `ExportedSessionKey`.
         let mut second_session =
             InboundGroupSession::import(&first_session.export_at(10).unwrap(), Default::default());
         assert!(!second_session.signing_key_verified);

--- a/src/megolm/message.rs
+++ b/src/megolm/message.rs
@@ -22,7 +22,7 @@ use crate::{
     DecodeError,
     cipher::{Cipher, Mac, MessageMac},
     types::{Ed25519Keypair, Ed25519Signature},
-    utilities::{VarInt, base64_decode, base64_encode, extract_mac},
+    utilities::{base64_decode, base64_encode, encode_protobuf_message, extract_mac},
 };
 #[cfg(feature = "low-level-api")]
 use crate::{Ed25519PublicKey, SignatureError};
@@ -143,7 +143,7 @@ impl MegolmMessage {
             ciphertext: self.ciphertext.clone(),
         };
 
-        message.encode_manual(self.version)
+        encode_protobuf_message(message, self.version)
     }
 
     fn set_mac(&mut self, mac: Mac) {
@@ -322,32 +322,10 @@ impl Debug for MegolmMessage {
 
 #[derive(Clone, Message, PartialEq, Eq)]
 struct ProtobufMegolmMessage {
-    #[prost(uint32, tag = "1")]
+    #[prost(uint32, required, tag = "1")]
     pub message_index: u32,
     #[prost(bytes, tag = "2")]
     pub ciphertext: Vec<u8>,
-}
-
-impl ProtobufMegolmMessage {
-    const INDEX_TAG: &'static [u8; 1] = b"\x08";
-    const CIPHER_TAG: &'static [u8; 1] = b"\x12";
-
-    fn encode_manual(&self, version: u8) -> Vec<u8> {
-        // Prost optimizes away the message index if it's 0, libolm can't decode
-        // this, so encode our messages the pedestrian way instead.
-        let index = self.message_index.to_var_int();
-        let ciphertext_len = self.ciphertext.len().to_var_int();
-
-        [
-            [version].as_ref(),
-            Self::INDEX_TAG.as_slice(),
-            &index,
-            Self::CIPHER_TAG.as_slice(),
-            &ciphertext_len,
-            &self.ciphertext,
-        ]
-        .concat()
-    }
 }
 
 #[cfg(test)]

--- a/src/megolm/ratchet.rs
+++ b/src/megolm/ratchet.rs
@@ -349,7 +349,8 @@ mod tests {
         {
             let parts = ratchet.as_parts();
 
-            // Now we advanced the zeroth part and put the result into the first part.
+            // Now we advanced the zeroth part and put the result into the first
+            // part.
             assert_eq!(parts.r_0.0, [0; 32]);
             assert_ne!(parts.r_1.0, [0; 32]);
             assert_eq!(parts.r_2.0, [0; 32]);
@@ -364,7 +365,8 @@ mod tests {
         {
             let parts = ratchet.as_parts();
 
-            // Now we advanced the third part and put the result into the second part.
+            // Now we advanced the third part and put the result into the second
+            // part.
             assert_eq!(parts.r_0.0, [0; 32]);
             assert_ne!(parts.r_1.0, [0; 32]);
             assert_ne!(parts.r_2.0, [0; 32]);
@@ -379,7 +381,8 @@ mod tests {
         {
             let parts = ratchet.as_parts();
 
-            // Now we advanced the second part and put the result into the zeroth part.
+            // Now we advanced the second part and put the result into the
+            // zeroth part.
             assert_eq!(parts.r_0.0, [0; 32]);
             assert_ne!(parts.r_1.0, [0; 32]);
             assert_ne!(parts.r_2.0, [0; 32]);
@@ -394,7 +397,8 @@ mod tests {
         {
             let parts = ratchet.as_parts();
 
-            // Now we advanced the second part and put the result into the zeroth part.
+            // Now we advanced the second part and put the result into the
+            // zeroth part.
             assert_ne!(parts.r_0.0, [0; 32]);
             assert_ne!(parts.r_1.0, [0; 32]);
             assert_ne!(parts.r_2.0, [0; 32]);

--- a/src/olm/account/mod.rs
+++ b/src/olm/account/mod.rs
@@ -1275,7 +1275,8 @@ mod test {
 
         account.generate_one_time_keys(50);
 
-        // Generate two fallback keys so the previous fallback key field gets populated.
+        // Generate two fallback keys so the previous fallback key field gets
+        // populated.
         account.generate_fallback_key();
         account.generate_fallback_key();
 
@@ -1794,9 +1795,9 @@ mod test {
 
         assert_matches2::assert_let!(OlmMessage::PreKey(mut pre_key_message) = pre_key_message);
 
-        // Technically this can't happen as the pre-key message parsing will reject such
-        // a version, but let's double check if our session creation is robust against
-        // unknown versions.
+        // Technically this can't happen as the pre-key message parsing will
+        // reject such a version, but let's double check if our session
+        // creation is robust against unknown versions.
         pre_key_message.message.version = 0xFF;
 
         let result = bob.create_inbound_session(

--- a/src/olm/account/one_time_keys.rs
+++ b/src/olm/account/one_time_keys.rs
@@ -80,8 +80,8 @@ impl OneTimeKeys {
         key: Curve25519SecretKey,
         published: bool,
     ) -> (Curve25519PublicKey, Option<Curve25519PublicKey>) {
-        // If we hit the max number of one-time keys we'd like to keep, first remove one
-        // before we create a new one.
+        // If we hit the max number of one-time keys we'd like to keep, first
+        // remove one before we create a new one.
         let removed = if self.private_keys.len() >= Self::MAX_ONE_TIME_KEYS {
             if let Some(key_id) = self.private_keys.keys().next().copied() {
                 let public_key = if let Some(private_key) = self.private_keys.remove(&key_id) {

--- a/src/olm/messages/message.rs
+++ b/src/olm/messages/message.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     Curve25519PublicKey, DecodeError,
     cipher::{Mac, MessageMac},
-    utilities::{VarInt, base64_decode, base64_encode, extract_mac},
+    utilities::{base64_decode, base64_encode, encode_protobuf_message, extract_mac},
 };
 
 pub(crate) const MAC_TRUNCATED_VERSION: u8 = 3;
@@ -143,12 +143,13 @@ impl Message {
     }
 
     fn encode(&self) -> Vec<u8> {
-        ProtoBufMessage {
+        let message = ProtoBufMessage {
             ratchet_key: self.ratchet_key.to_bytes().to_vec(),
             chain_index: self.chain_index,
             ciphertext: self.ciphertext.clone(),
-        }
-        .encode_manual(self.version)
+        };
+
+        encode_protobuf_message(message, self.version())
     }
 
     pub(crate) fn to_mac_bytes(&self) -> Vec<u8> {
@@ -254,35 +255,10 @@ impl Debug for Message {
 struct ProtoBufMessage {
     #[prost(bytes, tag = "1")]
     ratchet_key: Vec<u8>,
-    #[prost(uint64, tag = "2")]
+    #[prost(uint64, required, tag = "2")]
     chain_index: u64,
     #[prost(bytes, tag = "4")]
     ciphertext: Vec<u8>,
-}
-
-impl ProtoBufMessage {
-    const RATCHET_TAG: &'static [u8; 1] = b"\x0A";
-    const INDEX_TAG: &'static [u8; 1] = b"\x10";
-    const CIPHER_TAG: &'static [u8; 1] = b"\x22";
-
-    fn encode_manual(&self, version: u8) -> Vec<u8> {
-        let index = self.chain_index.to_var_int();
-        let ratchet_len = self.ratchet_key.len().to_var_int();
-        let ciphertext_len = self.ciphertext.len().to_var_int();
-
-        [
-            [version].as_ref(),
-            Self::RATCHET_TAG.as_slice(),
-            &ratchet_len,
-            &self.ratchet_key,
-            Self::INDEX_TAG.as_slice(),
-            &index,
-            Self::CIPHER_TAG.as_slice(),
-            &ciphertext_len,
-            &self.ciphertext,
-        ]
-        .concat()
-    }
 }
 
 #[cfg(test)]

--- a/src/olm/messages/pre_key.rs
+++ b/src/olm/messages/pre_key.rs
@@ -21,7 +21,7 @@ use super::Message;
 use crate::{
     Curve25519PublicKey, DecodeError,
     olm::SessionKeys,
-    utilities::{base64_decode, base64_encode},
+    utilities::{base64_decode, base64_encode, encode_protobuf_message},
 };
 
 /// An encrypted Olm pre-key message.
@@ -125,15 +125,7 @@ impl PreKeyMessage {
             message: self.message.to_bytes(),
         };
 
-        let mut output: Vec<u8> = vec![0u8; message.encoded_len() + 1];
-        output[0] = Self::VERSION;
-
-        #[allow(clippy::expect_used)]
-        message
-            .encode(&mut output[1..].as_mut())
-            .expect("We should be able to encode a pre-key message into protobuf.");
-
-        output
+        encode_protobuf_message(message, Self::VERSION)
     }
 
     /// Try to decode the given string as a Olm [`PreKeyMessage`].

--- a/src/olm/session/double_ratchet.rs
+++ b/src/olm/session/double_ratchet.rs
@@ -481,7 +481,8 @@ mod test {
             RatchetCount::Unknown(())
         );
 
-        // Once Bob replies, Alice's count bumps to 1, but Bob's remains unknown.
+        // Once Bob replies, Alice's count bumps to 1, but Bob's remains
+        // unknown.
         let olm_message = bob_session.encrypt("sssh").unwrap();
         alice_session.decrypt(&olm_message).expect("Alice could not decrypt message from Bob");
         assert_eq!(

--- a/src/olm/session/mod.rs
+++ b/src/olm/session/mod.rs
@@ -832,7 +832,8 @@ mod test {
                 .expect("Should be able to decrypt last message")
         );
 
-        // Cannot decrypt first message because it is more than MAX_MESSAGE_KEYS ago
+        // Cannot decrypt first message because it is more than MAX_MESSAGE_KEYS
+        // ago
         assert_matches!(
             alice_session.decrypt(&messages[0]),
             Err(DecryptionError::MissingMessageKey(_))

--- a/src/olm/session/receiver_chain.rs
+++ b/src/olm/session/receiver_chain.rs
@@ -200,17 +200,20 @@ impl ReceiverChain {
             // Advance the ratchet up until our desired point.
             while ratchet.chain_index() < chain_index {
                 if chain_index - ratchet.chain_index() > MAX_MESSAGE_KEYS as u64 {
-                    // If we're still too many messages away for us to save the skipped message
-                    // keys just advance the ratchet by one index. This avoids the expansion of a
+                    // If we're still too many messages away for us to save the
+                    // skipped message keys just advance the
+                    // ratchet by one index. This avoids the expansion of a
                     // message key we're going to throw away.
                     //
-                    // NOTE: Messages that were encrypted with the chain index of this loop
-                    // iteration will not have their message key anymore around. This does not mean
-                    // that any messages new messages, following the message at `chain_index`, will
-                    // be undecryptable.
+                    // NOTE: Messages that were encrypted with the chain index
+                    // of this loop iteration will not have
+                    // their message key anymore around. This does not mean
+                    // that any messages new messages, following the message at
+                    // `chain_index`, will be undecryptable.
                     ratchet.advance();
                 } else {
-                    // Otherwise advance the ratchet using the `create_message_key()` method and
+                    // Otherwise advance the ratchet using the
+                    // `create_message_key()` method and
                     // store the skipped key.
                     let key = ratchet.create_message_key();
                     skipped_keys.push(key);

--- a/src/pk_encryption.rs
+++ b/src/pk_encryption.rs
@@ -242,8 +242,9 @@ impl PkDecryption {
         let hmac = HmacSha256::new_from_slice(cipher_keys.mac_key())
             .expect("We should be able to create a Hmac object from a 32 byte key");
 
-        // BUG: This is a know issue, we check the MAC of an empty message instead of
-        // updating the `hmac` object with the ciphertext bytes.
+        // BUG: This is a know issue, we check the MAC of an empty message
+        // instead of updating the `hmac` object with the ciphertext
+        // bytes.
         hmac.verify_truncated_left(&message.mac)?;
 
         let cipher = Aes256CbcDec::new(cipher_keys.aes_key(), cipher_keys.iv());
@@ -322,8 +323,9 @@ impl PkEncryption {
         let hmac = HmacSha256::new_from_slice(cipher_keys.mac_key())
             .expect("We should be able to create a Hmac object from a 32 byte key");
 
-        // BUG: This is a know issue, we create a MAC of an empty message instead of
-        // updating the `hmac` object with the ciphertext bytes.
+        // BUG: This is a know issue, we create a MAC of an empty message
+        // instead of updating the `hmac` object with the ciphertext
+        // bytes.
         let mut mac = hmac.finalize().into_bytes().to_vec();
         mac.truncate(Mac::TRUNCATED_LEN);
 

--- a/src/sas.rs
+++ b/src/sas.rs
@@ -172,8 +172,8 @@ impl SasBytes {
     /// [spec]: https://spec.matrix.org/unstable/client-server-api/#sas-method-emoji
     fn bytes_to_emoji_index(bytes: &[u8; 6]) -> [u8; 7] {
         let bytes: Vec<u64> = bytes.iter().map(|b| *b as u64).collect();
-        // Join the 6 bytes into one 64 bit unsigned int. This u64 will contain 48
-        // bits from our 6 bytes.
+        // Join the 6 bytes into one 64 bit unsigned int. This u64 will contain
+        // 48 bits from our 6 bytes.
         let mut num: u64 = bytes[0] << 40;
         num += bytes[1] << 32;
         num += bytes[2] << 24;
@@ -181,8 +181,8 @@ impl SasBytes {
         num += bytes[4] << 8;
         num += bytes[5];
 
-        // Take the top 42 bits of our 48 bits from the u64 and convert each 6 bits
-        // into a 6 bit number.
+        // Take the top 42 bits of our 48 bits from the u64 and convert each 6
+        // bits into a 6 bit number.
         [
             ((num >> 42) & 63) as u8,
             ((num >> 36) & 63) as u8,

--- a/src/types/ed25519.rs
+++ b/src/types/ed25519.rs
@@ -254,9 +254,9 @@ impl Ed25519SecretKey {
                 length: decoded_len_estimate(input.len()),
             })
         } else {
-            // Ed25519 secret keys can sometimes be encoded with padding, don't ask me why.
-            // This means that if the unpadded decoding fails, we have to attempt the padded
-            // one.
+            // Ed25519 secret keys can sometimes be encoded with padding, don't
+            // ask me why. This means that if the unpadded decoding
+            // fails, we have to attempt the padded one.
             let mut bytes = if let Ok(bytes) = base64ct::Base64Unpadded::decode_vec(input) {
                 bytes
             } else {

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -22,6 +22,7 @@ use base64::{
 pub(crate) use libolm_compat::get_version as get_pickle_version;
 #[cfg(feature = "libolm-compat")]
 pub(crate) use libolm_compat::{LibolmEd25519Keypair, pickle_libolm, unpickle_libolm};
+use prost::Message;
 
 const STANDARD_NO_PAD: GeneralPurpose = GeneralPurpose::new(
     &alphabet::STANDARD,
@@ -89,74 +90,26 @@ pub(crate) fn extract_mac(slice: &[u8], truncated: bool) -> crate::cipher::Messa
     }
 }
 
-// The integer encoding logic here has been taken from the integer-encoding[1]
-// crate and is under the MIT license.
-//
-// The MIT License (MIT)
-//
-// Copyright (c) 2016 Google Inc. (lewinb@google.com) -- though not an official
-// Google product or in any way related!
-// Copyright (c) 2018-2020 Lewin Bormann (lbo@spheniscida.de)
-//
-// [1]: https://github.com/dermesser/integer-encoding-rs
-pub(crate) trait VarInt {
-    fn to_var_int(self) -> Vec<u8>;
-}
+/// Generic method to encode a [`Message`] into a newly allocated buffer.
+///
+/// We're not using [Message::encode_to_vec] directly because we want to prepend
+/// a version to our protobuf encoded message. Likewise, when we decode, we
+/// first want to look at the first byte for the version before we decide how to
+/// decode the message.
+pub(crate) fn encode_protobuf_message(message: impl Message, message_version: u8) -> Vec<u8> {
+    let mut output: Vec<u8> = vec![0u8; message.encoded_len() + 1];
+    output[0] = message_version;
 
-/// Most-significant byte, == 0x80
-const MSB: u8 = 0b1000_0000;
+    #[allow(clippy::expect_used)]
+    message
+        .encode(&mut output[1..].as_mut())
+        .expect("We should be able to encode a message into protobuf.");
 
-/// How many bytes an integer uses when being encoded as a VarInt.
-#[inline]
-const fn required_encoded_space_unsigned(mut v: u64) -> usize {
-    if v == 0 {
-        return 1;
-    }
-
-    let mut logcounter = 0;
-    while v > 0 {
-        logcounter += 1;
-        v >>= 7;
-    }
-    logcounter
-}
-
-impl VarInt for usize {
-    fn to_var_int(self) -> Vec<u8> {
-        (self as u64).to_var_int()
-    }
-}
-
-impl VarInt for u32 {
-    fn to_var_int(self) -> Vec<u8> {
-        (self as u64).to_var_int()
-    }
-}
-
-impl VarInt for u64 {
-    #[inline]
-    fn to_var_int(self) -> Vec<u8> {
-        let mut v = vec![0u8; required_encoded_space_unsigned(self)];
-
-        let mut n = self;
-        let mut i = 0;
-
-        while n >= 0x80 {
-            v[i] = MSB | (n as u8);
-            i += 1;
-            n >>= 7;
-        }
-
-        v[i] = n as u8;
-
-        v
-    }
+    output
 }
 
 #[cfg(test)]
 mod test {
-    use ntest::timeout;
-
     use super::*;
 
     #[test]
@@ -172,18 +125,5 @@ mod test {
             first, second,
             "Decoding the same base64 string with and without padding should produce the same result"
         )
-    }
-
-    #[test]
-    #[timeout(10)]
-    fn integer_encoding_required_space() {
-        assert_eq!(required_encoded_space_unsigned(0), 1);
-        assert_eq!(required_encoded_space_unsigned(100), 1);
-        assert_eq!(required_encoded_space_unsigned(1000), 2);
-        assert_eq!(required_encoded_space_unsigned(10000), 2);
-        assert_eq!(required_encoded_space_unsigned(100000), 3);
-        assert_eq!(required_encoded_space_unsigned(1000000), 3);
-        assert_eq!(required_encoded_space_unsigned(10000000), 4);
-        assert_eq!(required_encoded_space_unsigned(1000000000), 5);
     }
 }


### PR DESCRIPTION
This ensures that the fields won't be omitted if they contain the default value 0.

This removes the need for our custom encode_manual methods while retaining libolm compatibility.

Took a while before coming back to this.