### PR TITLE
ci: Don't run tests for each feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,8 @@ jobs:
     - name: Check that our features compile
       run: cargo hack check --each-feature --no-dev-deps
 
-    - name: Check that our tests pass for each feature set
-      run: cargo hack test --each-feature
+    - name: Check that our tests compile for each feature set as well
+      run: cargo hack check --each-feature --all-targets
 
   test:
     name: ${{ matrix.target.name }} ${{ matrix.channel }}


### PR DESCRIPTION
Since we nowadays have a "please-be-dont-be-slow" feature, running tests without this feature is quite horrible.

So let's just check that the tests compile.